### PR TITLE
Clean log

### DIFF
--- a/server/server/data/src/main/java/com/alipay/sofa/registry/server/data/change/event/DataChangeEventQueue.java
+++ b/server/server/data/src/main/java/com/alipay/sofa/registry/server/data/change/event/DataChangeEventQueue.java
@@ -260,8 +260,6 @@ public class DataChangeEventQueue {
                         "[{}] client off handle, connectId={}, occurTimestamp={}, version={}, handle pubSize={}",
                         getName(), connectId, event.getOccurredTimestamp(), event.getVersion(),
                         count);
-            } else {
-                LOGGER.info("[{}] no datum to handle, connectId={}", getName(), connectId);
             }
         }
     }

--- a/server/server/data/src/main/resources/logback-spring.xml
+++ b/server/server/data/src/main/resources/logback-spring.xml
@@ -105,7 +105,7 @@
         <file>${DATA_LOG_HOME}/registry-data.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <FileNamePattern>${DATA_LOG_HOME}/registry-data.log.%d{yyyy-MM-dd}</FileNamePattern>
-            <MaxHistory>30</MaxHistory>
+            <MaxHistory>3</MaxHistory>
         </rollingPolicy>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>[%d{ISO8601}][%p][%t][%c{0}] - %m%n</pattern>
@@ -164,8 +164,8 @@
         </filter>
         <file>${DATA_LOG_HOME}/cache-digest.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <FileNamePattern>${DATA_LOG_HOME}/cache-digest.log.%d{yyyy-MM-dd}</FileNamePattern>
-            <MaxHistory>30</MaxHistory>
+            <FileNamePattern>${DATA_LOG_HOME}/cache-digest.log.%d{yyyy-MM-dd_HH}</FileNamePattern>
+            <MaxHistory>72</MaxHistory>
         </rollingPolicy>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>[%d{ISO8601}][%p][%t][%c{0}] - %m%n</pattern>
@@ -224,8 +224,8 @@
         </filter>
         <file>${DATA_LOG_HOME}/registry-exchange.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <FileNamePattern>${DATA_LOG_HOME}/registry-exchange.log.%d{yyyy-MM-dd}</FileNamePattern>
-            <MaxHistory>30</MaxHistory>
+            <FileNamePattern>${DATA_LOG_HOME}/registry-exchange.log.%d{yyyy-MM-dd_HH}</FileNamePattern>
+            <MaxHistory>72</MaxHistory>
         </rollingPolicy>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>[%d{ISO8601}][%p][%t][%c{0}] - %m%n</pattern>

--- a/server/server/data/src/test/resources/logback-test.xml
+++ b/server/server/data/src/test/resources/logback-test.xml
@@ -39,7 +39,7 @@
         <file>${LOG_HOME}/registry-data.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <FileNamePattern>${LOG_HOME}/registry-data.log.%d{yyyy-MM-dd}</FileNamePattern>
-            <MaxHistory>30</MaxHistory>
+            <MaxHistory>3</MaxHistory>
         </rollingPolicy>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>[%d{ISO8601}][%p][%t][%c{0}] - %m%n</pattern>

--- a/server/server/integration/src/main/resources/logback-spring.xml
+++ b/server/server/integration/src/main/resources/logback-spring.xml
@@ -213,7 +213,7 @@
         <file>${DATA_LOG_HOME}/registry-data.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <FileNamePattern>${DATA_LOG_HOME}/registry-data.log.%d{yyyy-MM-dd}</FileNamePattern>
-            <MaxHistory>30</MaxHistory>
+            <MaxHistory>3</MaxHistory>
         </rollingPolicy>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>[%d{ISO8601}][%p][%t][%c{0}] - %m%n</pattern>
@@ -252,8 +252,8 @@
         </filter>
         <file>${DATA_LOG_HOME}/cache-digest.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <FileNamePattern>${DATA_LOG_HOME}/cache-digest.log.%d{yyyy-MM-dd}</FileNamePattern>
-            <MaxHistory>30</MaxHistory>
+            <FileNamePattern>${DATA_LOG_HOME}/cache-digest.log.%d{yyyy-MM-dd_HH}</FileNamePattern>
+            <MaxHistory>72</MaxHistory>
         </rollingPolicy>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>[%d{ISO8601}][%p][%t][%c{0}] - %m%n</pattern>
@@ -335,7 +335,7 @@
         <file>${SESSION_LOG_HOME}/registry-session.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <FileNamePattern>${SESSION_LOG_HOME}/registry-session.log.%d{yyyy-MM-dd}</FileNamePattern>
-            <MaxHistory>30</MaxHistory>
+            <MaxHistory>3</MaxHistory>
         </rollingPolicy>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>[%d{ISO8601}][%p][%t][%c{0}] - %m%n</pattern>
@@ -394,8 +394,8 @@
         </filter>
         <file>${SESSION_LOG_HOME}/registry-exchange.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <FileNamePattern>${SESSION_LOG_HOME}/registry-exchange.log.%d{yyyy-MM-dd}</FileNamePattern>
-            <MaxHistory>30</MaxHistory>
+            <FileNamePattern>${SESSION_LOG_HOME}/registry-exchange.log.%d{yyyy-MM-dd_HH}</FileNamePattern>
+            <MaxHistory>72</MaxHistory>
         </rollingPolicy>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>[%d{ISO8601}][%p][%t][%c{0}] - %m%n</pattern>
@@ -414,8 +414,8 @@
         </filter>
         <file>${SESSION_LOG_HOME}/registry-push.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <FileNamePattern>${SESSION_LOG_HOME}/registry-push.log.%d{yyyy-MM-dd}</FileNamePattern>
-            <MaxHistory>30</MaxHistory>
+            <FileNamePattern>${SESSION_LOG_HOME}/registry-push.log.%d{yyyy-MM-dd_HH}</FileNamePattern>
+            <MaxHistory>72</MaxHistory>
         </rollingPolicy>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>[%d{ISO8601}][%p][%t][%c{0}] - %m%n</pattern>

--- a/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/scheduler/task/DataChangeFetchCloudTask.java
+++ b/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/scheduler/task/DataChangeFetchCloudTask.java
@@ -275,6 +275,7 @@ public class DataChangeFetchCloudTask extends AbstractSessionTask {
         TaskEvent taskEvent = new TaskEvent(parameter, TaskType.RECEIVED_DATA_MULTI_PUSH_TASK);
         taskEvent.setTaskClosure(pushTaskClosure);
         taskEvent.setAttribute(Constant.PUSH_CLIENT_SUBSCRIBERS, subscribers);
+
         taskLogger.info("send {} taskURL:{},taskScope:{},version:{},taskId={}",
             taskEvent.getTaskType(), subscriber.getSourceAddress(), scopeEnum,
             receivedData.getVersion(), taskEvent.getTaskId());

--- a/server/server/session/src/main/resources/logback-spring.xml
+++ b/server/server/session/src/main/resources/logback-spring.xml
@@ -105,7 +105,7 @@
         <file>${SESSION_LOG_HOME}/registry-session.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <FileNamePattern>${SESSION_LOG_HOME}/registry-session.log.%d{yyyy-MM-dd}</FileNamePattern>
-            <MaxHistory>30</MaxHistory>
+            <MaxHistory>3</MaxHistory>
         </rollingPolicy>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>[%d{ISO8601}][%p][%t][%c{0}] - %m%n</pattern>
@@ -184,8 +184,8 @@
         </filter>
         <file>${SESSION_LOG_HOME}/registry-exchange.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <FileNamePattern>${SESSION_LOG_HOME}/registry-exchange.log.%d{yyyy-MM-dd}</FileNamePattern>
-            <MaxHistory>30</MaxHistory>
+            <FileNamePattern>${SESSION_LOG_HOME}/registry-exchange.log.%d{yyyy-MM-dd_HH}</FileNamePattern>
+            <MaxHistory>72</MaxHistory>
         </rollingPolicy>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>[%d{ISO8601}][%p][%t][%c{0}] - %m%n</pattern>
@@ -204,8 +204,8 @@
         </filter>
         <file>${SESSION_LOG_HOME}/registry-push.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <FileNamePattern>${SESSION_LOG_HOME}/registry-push.log.%d{yyyy-MM-dd}</FileNamePattern>
-            <MaxHistory>30</MaxHistory>
+            <FileNamePattern>${SESSION_LOG_HOME}/registry-push.log.%d{yyyy-MM-dd_HH}</FileNamePattern>
+            <MaxHistory>72</MaxHistory>
         </rollingPolicy>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>[%d{ISO8601}][%p][%t][%c{0}] - %m%n</pattern>


### PR DESCRIPTION
### Motivation:

since registry-data.log，registry-session.log，registry-exchange.log, cache-digest.log print too much, and currently log is split by day. The log file is too large and the server disk will be easily full up.


### Result:

Fixes #<139>. 

If there is no issue then describe the changes introduced by this PR.
https://github.com/sofastack/sofa-registry/issues/139