### PR TITLE
chore: manage version of maven plugin in order to remove build warning

### DIFF
--- a/client/api/pom.xml
+++ b/client/api/pom.xml
@@ -33,7 +33,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>

--- a/client/impl/pom.xml
+++ b/client/impl/pom.xml
@@ -86,7 +86,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>

--- a/client/log/pom.xml
+++ b/client/log/pom.xml
@@ -38,7 +38,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -81,7 +81,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -33,7 +33,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
         <rocksdbjni.version>6.4.6</rocksdbjni.version>
         <main.user.dir>${user.dir}</main.user.dir>
         <argLine>-Dnetwork_interface_denylist=docker0</argLine>
+        <springboot.version>1.5.17.RELEASE</springboot.version>
     </properties>
 
     <dependencyManagement>
@@ -94,7 +95,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-parent</artifactId>
-                <version>1.5.17.RELEASE</version>
+                <version>${springboot.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -353,6 +354,35 @@
     </dependencyManagement>
 
     <build>
+    	<pluginManagement>
+    		<plugins>
+    			 <plugin>
+	                <groupId>org.apache.maven.plugins</groupId>
+	                <artifactId>maven-compiler-plugin</artifactId>
+	                <version>3.7.0</version>
+	            </plugin>
+	            <plugin>
+	                <groupId>org.apache.maven.plugins</groupId>
+	                <artifactId>maven-install-plugin</artifactId>
+	                <version>3.0.0-M1</version>
+	            </plugin>
+	            <plugin>
+	                <groupId>org.apache.maven.plugins</groupId>
+	                <artifactId>maven-deploy-plugin</artifactId>
+	                <version>3.0.0-M1</version>
+	            </plugin>
+	            <plugin>
+	                <groupId>org.sonatype.plugins</groupId>
+	                <artifactId>nexus-staging-maven-plugin</artifactId>
+	                <version>1.6.7</version>
+	            </plugin>
+	            <plugin>
+	            	<groupId>org.springframework.boot</groupId>
+				    <artifactId>spring-boot-maven-plugin</artifactId>
+				    <version>${springboot.version}</version>
+	            </plugin>
+    		</plugins>
+    	</pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -42,7 +42,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>


### PR DESCRIPTION

### Motivation:

when execute command 'mvn clean install ', the fllowing warnings show
up:

```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.alipay.sofa:registry-client-api:jar:5.4.5
[WARNING] 'build.plugins.plugin.version' for org.sonatype.plugins:nexus-staging-maven-plugin is missing. @ line 57, column 21
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-install-plugin is missing. @ line 43, column 21
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ line 50, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.alipay.sofa:registry-client-log:jar:5.4.5
[WARNING] 'build.plugins.plugin.version' for org.sonatype.plugins:nexus-staging-maven-plugin is missing. @ line 62, column 21
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-install-plugin is missing. @ line 48, column 21
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ line 55, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.alipay.sofa:registry-client-impl:jar:5.4.5
[WARNING] 'build.plugins.plugin.version' for org.sonatype.plugins:nexus-staging-maven-plugin is missing. @ line 110, column 21
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-install-plugin is missing. @ line 96, column 21
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ line 103, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.alipay.sofa:registry-client-parent:pom:5.4.5
[WARNING] 'build.plugins.plugin.version' for org.sonatype.plugins:nexus-staging-maven-plugin is missing. @ line 105, column 21
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-install-plugin is missing. @ line 91, column 21
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ line 98, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.alipay.sofa:registry-server-session:jar:5.4.5
[WARNING] 'build.plugins.plugin.version' for org.springframework.boot:spring-boot-maven-plugin is missing. @ line 91, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.alipay.sofa:registry-server-data:jar:5.4.5
[WARNING] 'build.plugins.plugin.version' for org.springframework.boot:spring-boot-maven-plugin is missing. @ line 95, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.alipay.sofa:registry-server-meta:jar:5.4.5
[WARNING] 'build.plugins.plugin.version' for org.springframework.boot:spring-boot-maven-plugin is missing. @ line 102, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.alipay.sofa:registry-server-integration:jar:5.4.5
[WARNING] 'build.plugins.plugin.version' for org.springframework.boot:spring-boot-maven-plugin is missing. @ line 45, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.alipay.sofa:registry-distribution-session:pom:5.4.5
[WARNING] 'build.plugins.plugin.version' for org.sonatype.plugins:nexus-staging-maven-plugin is missing. @ line 43, column 21
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-install-plugin is missing. @ line 29, column 21
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ line 36, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.alipay.sofa:registry-distribution-data:pom:5.4.5
[WARNING] 'build.plugins.plugin.version' for org.sonatype.plugins:nexus-staging-maven-plugin is missing. @ line 43, column 21
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-install-plugin is missing. @ line 29, column 21
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ line 36, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.alipay.sofa:registry-distribution-meta:pom:5.4.5
[WARNING] 'build.plugins.plugin.version' for org.sonatype.plugins:nexus-staging-maven-plugin is missing. @ line 43, column 21
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-install-plugin is missing. @ line 29, column 21
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ line 36, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.alipay.sofa:registry-distribution-integration:pom:5.4.5
[WARNING] 'build.plugins.plugin.version' for org.sonatype.plugins:nexus-staging-maven-plugin is missing. @ line 42, column 21
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-install-plugin is missing. @ line 28, column 21
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ line 35, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.alipay.sofa:registry-distribution:pom:5.4.5
[WARNING] 'build.plugins.plugin.version' for org.sonatype.plugins:nexus-staging-maven-plugin is missing. @ line 47, column 21
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-install-plugin is missing. @ line 33, column 21
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ line 40, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```

### Modification:

just add pluginManagement in the parent registry-parent/pom.xml: 

```xml
    	<pluginManagement>
    		<plugins>
    		    <plugin>
	                <groupId>org.apache.maven.plugins</groupId>
	                <artifactId>maven-compiler-plugin</artifactId>
	                <version>3.7.0</version>
	            </plugin>
	            <plugin>
	                <groupId>org.apache.maven.plugins</groupId>
	                <artifactId>maven-install-plugin</artifactId>
	                <version>3.0.0-M1</version>
	            </plugin>
	            <plugin>
	                <groupId>org.apache.maven.plugins</groupId>
	                <artifactId>maven-deploy-plugin</artifactId>
	                <version>3.0.0-M1</version>
	            </plugin>
	            <plugin>
	                <groupId>org.sonatype.plugins</groupId>
	                <artifactId>nexus-staging-maven-plugin</artifactId>
	                <version>1.6.7</version>
	            </plugin>
	            <plugin>
	            	<groupId>org.springframework.boot</groupId>
	                <artifactId>spring-boot-maven-plugin</artifactId>
		        <version>${springboot.version}</version>
	            </plugin>
    		</plugins>
    	</pluginManagement>
```

### Result:

the warnings just disappear.
