### PR TITLE
Update README.md to suggest other developers to use Java JDK 8 rather than JDK 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ SOFARegistry 是蚂蚁金服开源的一个生产级、高时效、高可用的�
 
 运行需要 JDK 6 及以上，服务端运行需要 JDK 8及以上。
 
+****推荐使用JDK 8，JDK 16尚未被测试，可能会有兼容性问题。**
+
 ## 文档
 
 - [快速开始](https://www.sofastack.tech/sofa-registry/docs/Server-QuickStart)


### PR DESCRIPTION
Update JDK recommendation on README.md (#165)

### Motivation:

As discussed on #165, we come up that the JDK 16 has some compatibility problems when starting the sofa-registry server. It would be more clear to the developers if we add the suggestion on README.

### Modification:

Added `**推荐使用JDK 8，JDK 16尚未被测试，可能会有兼容性问题。` on README.md

### Result:

Fixes #165 . 



