### PR TITLE
Add client direct connect

### DIFF
--- a/client/impl/src/main/java/com/alipay/sofa/registry/client/provider/DirectServerManager.java
+++ b/client/impl/src/main/java/com/alipay/sofa/registry/client/provider/DirectServerManager.java
@@ -33,21 +33,21 @@ import java.util.List;
  */
 public class DirectServerManager implements ServerManager {
 
-    private final List<ServerNode> serverNodes;
+  private final List<ServerNode> serverNodes;
 
-    public DirectServerManager(RegistryClientConfig config) {
-        this.serverNodes = new ArrayList<ServerNode>();
-        this.serverNodes.add(
-                ServerNodeParser.parse(String.format("%s:%s", config.getRegistryEndpoint(), config.getRegistryEndpoint())));
-    }
+  public DirectServerManager(RegistryClientConfig config) {
+    this.serverNodes = new ArrayList<ServerNode>();
+    this.serverNodes.add(
+        ServerNodeParser.parse(String.format("%s:%s", config.getRegistryEndpoint(), config.getRegistryEndpoint())));
+  }
 
-    @Override
-    public List<ServerNode> getServerList() {
-        return serverNodes;
-    }
+  @Override
+  public List<ServerNode> getServerList() {
+    return serverNodes;
+  }
 
-    @Override
-    public ServerNode random() {
-        return serverNodes.get(0);
-    }
+  @Override
+  public ServerNode random() {
+    return serverNodes.get(0);
+  }
 }

--- a/client/impl/src/main/java/com/alipay/sofa/registry/client/provider/DirectServerManager.java
+++ b/client/impl/src/main/java/com/alipay/sofa/registry/client/provider/DirectServerManager.java
@@ -20,6 +20,7 @@ import com.alipay.sofa.registry.client.api.RegistryClientConfig;
 import com.alipay.sofa.registry.client.remoting.ServerManager;
 import com.alipay.sofa.registry.client.remoting.ServerNode;
 import com.alipay.sofa.registry.client.util.ServerNodeParser;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,21 +33,21 @@ import java.util.List;
  */
 public class DirectServerManager implements ServerManager {
 
-  private final List<ServerNode> serverNodes;
+    private final List<ServerNode> serverNodes;
 
-  public DirectServerManager(RegistryClientConfig config) {
-    this.serverNodes = new ArrayList<ServerNode>();
-    this.serverNodes.add(
-        ServerNodeParser.parse(String.format("%s:9600", config.getRegistryEndpoint())));
-  }
+    public DirectServerManager(RegistryClientConfig config) {
+        this.serverNodes = new ArrayList<ServerNode>();
+        this.serverNodes.add(
+                ServerNodeParser.parse(String.format("%s:%s", config.getRegistryEndpoint(), config.getRegistryEndpoint())));
+    }
 
-  @Override
-  public List<ServerNode> getServerList() {
-    return serverNodes;
-  }
+    @Override
+    public List<ServerNode> getServerList() {
+        return serverNodes;
+    }
 
-  @Override
-  public ServerNode random() {
-    return serverNodes.get(0);
-  }
+    @Override
+    public ServerNode random() {
+        return serverNodes.get(0);
+    }
 }

--- a/client/impl/src/main/java/com/alipay/sofa/registry/client/provider/DirectServerManager.java
+++ b/client/impl/src/main/java/com/alipay/sofa/registry/client/provider/DirectServerManager.java
@@ -20,34 +20,33 @@ import com.alipay.sofa.registry.client.api.RegistryClientConfig;
 import com.alipay.sofa.registry.client.remoting.ServerManager;
 import com.alipay.sofa.registry.client.remoting.ServerNode;
 import com.alipay.sofa.registry.client.util.ServerNodeParser;
-
 import java.util.ArrayList;
 import java.util.List;
 
 /**
- * The type Direct server manager.
- * Return server node RegistryClientConfig.getRegistryEndpoint()+ PORT 9600
+ * The type Direct server manager. Return server node RegistryClientConfig.getRegistryEndpoint()+
+ * PORT 9600
  *
  * @author zhiqiang.li
  * @version $Id : DirectServerManager.java, v 0.1 2022-03-18 13:37 zhiqiang.li Exp $$
  */
 public class DirectServerManager implements ServerManager {
 
-    private final List<ServerNode> serverNodes;
+  private final List<ServerNode> serverNodes;
 
-    public DirectServerManager(RegistryClientConfig config) {
-        this.serverNodes = new ArrayList<ServerNode>();
-        this.serverNodes.add(ServerNodeParser.parse(String.format("%s:9600", config.getRegistryEndpoint())));
-    }
+  public DirectServerManager(RegistryClientConfig config) {
+    this.serverNodes = new ArrayList<ServerNode>();
+    this.serverNodes.add(
+        ServerNodeParser.parse(String.format("%s:9600", config.getRegistryEndpoint())));
+  }
 
+  @Override
+  public List<ServerNode> getServerList() {
+    return serverNodes;
+  }
 
-    @Override
-    public List<ServerNode> getServerList() {
-        return serverNodes;
-    }
-
-    @Override
-    public ServerNode random() {
-        return serverNodes.get(0);
-    }
+  @Override
+  public ServerNode random() {
+    return serverNodes.get(0);
+  }
 }

--- a/client/impl/src/main/java/com/alipay/sofa/registry/client/provider/DirectServerManager.java
+++ b/client/impl/src/main/java/com/alipay/sofa/registry/client/provider/DirectServerManager.java
@@ -20,7 +20,6 @@ import com.alipay.sofa.registry.client.api.RegistryClientConfig;
 import com.alipay.sofa.registry.client.remoting.ServerManager;
 import com.alipay.sofa.registry.client.remoting.ServerNode;
 import com.alipay.sofa.registry.client.util.ServerNodeParser;
-
 import java.util.ArrayList;
 import java.util.List;
 

--- a/client/impl/src/main/java/com/alipay/sofa/registry/client/provider/DirectServerManager.java
+++ b/client/impl/src/main/java/com/alipay/sofa/registry/client/provider/DirectServerManager.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.registry.client.provider;
+
+import com.alipay.sofa.registry.client.api.RegistryClientConfig;
+import com.alipay.sofa.registry.client.remoting.ServerManager;
+import com.alipay.sofa.registry.client.remoting.ServerNode;
+import com.alipay.sofa.registry.client.util.ServerNodeParser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The type Direct server manager.
+ * Return server node RegistryClientConfig.getRegistryEndpoint()+ PORT 9600
+ *
+ * @author zhiqiang.li
+ * @version $Id : DirectServerManager.java, v 0.1 2022-03-18 13:37 zhiqiang.li Exp $$
+ */
+public class DirectServerManager implements ServerManager {
+
+    private final List<ServerNode> serverNodes;
+
+    public DirectServerManager(RegistryClientConfig config) {
+        this.serverNodes = new ArrayList<ServerNode>();
+        this.serverNodes.add(ServerNodeParser.parse(String.format("%s:9600", config.getRegistryEndpoint())));
+    }
+
+
+    @Override
+    public List<ServerNode> getServerList() {
+        return serverNodes;
+    }
+
+    @Override
+    public ServerNode random() {
+        return serverNodes.get(0);
+    }
+}

--- a/client/impl/src/test/java/com/alipay/sofa/registry/client/provider/DirectServerManagerTest.java
+++ b/client/impl/src/test/java/com/alipay/sofa/registry/client/provider/DirectServerManagerTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.registry.client.provider;
+
+import com.alipay.sofa.registry.client.api.RegistryClientConfig;
+import com.alipay.sofa.registry.client.remoting.ServerManager;
+import com.alipay.sofa.registry.client.remoting.ServerNode;
+import com.alipay.sofa.registry.client.util.HttpClientUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.List;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author zhiqiang.li
+ * @version $Id: DirectServerManagerTest.java, v 0.1 2022-03-18 13:37 zhiqiang.li Exp $$
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(HttpClientUtils.class)
+public class DirectServerManagerTest {
+
+    @Test
+    public void initServerList() throws Exception {
+        // given
+        PowerMockito.mockStatic(HttpClientUtils.class);
+        RegistryClientConfig config = mock(RegistryClientConfig.class);
+
+        // when
+        when(config.getRegistryEndpoint()).thenReturn("127.0.0.1");
+
+        // then
+        ServerManager serverManager = new DirectServerManager(config);
+
+        List<ServerNode> serverList = serverManager.getServerList();
+        ServerNode node = serverManager.random();
+
+        assertNotNull(serverList);
+        assertNotNull(node);
+        Assert.assertEquals(serverList.size(), 1);
+        Assert.assertEquals("127.0.0.1:9600", node.getUrl());
+    }
+}

--- a/client/impl/src/test/java/com/alipay/sofa/registry/client/provider/DirectServerManagerTest.java
+++ b/client/impl/src/test/java/com/alipay/sofa/registry/client/provider/DirectServerManagerTest.java
@@ -16,21 +16,20 @@
  */
 package com.alipay.sofa.registry.client.provider;
 
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.*;
+
 import com.alipay.sofa.registry.client.api.RegistryClientConfig;
 import com.alipay.sofa.registry.client.remoting.ServerManager;
 import com.alipay.sofa.registry.client.remoting.ServerNode;
 import com.alipay.sofa.registry.client.util.HttpClientUtils;
+import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-
-import java.util.List;
-
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.*;
 
 /**
  * @author zhiqiang.li
@@ -40,24 +39,24 @@ import static org.mockito.Mockito.*;
 @PrepareForTest(HttpClientUtils.class)
 public class DirectServerManagerTest {
 
-    @Test
-    public void initServerList() {
-        // given
-        PowerMockito.mockStatic(HttpClientUtils.class);
-        RegistryClientConfig config = mock(RegistryClientConfig.class);
+  @Test
+  public void initServerList() {
+    // given
+    PowerMockito.mockStatic(HttpClientUtils.class);
+    RegistryClientConfig config = mock(RegistryClientConfig.class);
 
-        // when
-        when(config.getRegistryEndpoint()).thenReturn("127.0.0.1");
+    // when
+    when(config.getRegistryEndpoint()).thenReturn("127.0.0.1");
 
-        // then
-        ServerManager serverManager = new DirectServerManager(config);
+    // then
+    ServerManager serverManager = new DirectServerManager(config);
 
-        List<ServerNode> serverList = serverManager.getServerList();
-        ServerNode node = serverManager.random();
+    List<ServerNode> serverList = serverManager.getServerList();
+    ServerNode node = serverManager.random();
 
-        assertNotNull(serverList);
-        assertNotNull(node);
-        Assert.assertEquals(serverList.size(), 1);
-        Assert.assertEquals("127.0.0.1:9600", node.getUrl());
-    }
+    assertNotNull(serverList);
+    assertNotNull(node);
+    Assert.assertEquals(serverList.size(), 1);
+    Assert.assertEquals("127.0.0.1:9600", node.getUrl());
+  }
 }

--- a/client/impl/src/test/java/com/alipay/sofa/registry/client/provider/DirectServerManagerTest.java
+++ b/client/impl/src/test/java/com/alipay/sofa/registry/client/provider/DirectServerManagerTest.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.*;
 public class DirectServerManagerTest {
 
     @Test
-    public void initServerList() throws Exception {
+    public void initServerList() {
         // given
         PowerMockito.mockStatic(HttpClientUtils.class);
         RegistryClientConfig config = mock(RegistryClientConfig.class);


### PR DESCRIPTION
### Motivation:

Adapt to docker-compose

### Modification:

Add new ServerManager impl DirectServerManager，return only one ServerNode: RegistryClientConfig.getRegistryEndpoint()+ PORT 9600

Usage:

````java
DefaultRegistryClientConfig config =
    DefaultRegistryClientConfigBuilder.start()
        .setAppName(appName)
        .setDataCenter(dataCenter)
        .setInstanceId(instanceId)
        .setRegistryEndpoint("127.0.0.1")
        .build();
registryClient = new DefaultRegistryClient(config);
registryClient.setServerManager(new DirectServerManager(config));
registryClient.init();
````

### Result:

Fixes #209

If there is no issue then describe the changes introduced by this PR.
