### PR TITLE
修复RegistryCoreOpsResource关流量

### DIFF
--- a/client/all/pom.xml
+++ b/client/all/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.alipay.sofa</groupId>
     <artifactId>registry-client-all</artifactId>
-    <version>6.1.5-SNAPSHOT</version>
+    <version>6.1.5</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <url>http://github.com/alipay/sofa-registry</url>

--- a/client/api/pom.xml
+++ b/client/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>registry-client-parent</artifactId>
-        <version>6.1.5-SNAPSHOT</version>
+        <version>6.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/client/impl/pom.xml
+++ b/client/impl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>registry-client-parent</artifactId>
-        <version>6.1.5-SNAPSHOT</version>
+        <version>6.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/client/impl/src/main/java/com/alipay/sofa/registry/client/provider/DirectServerManager.java
+++ b/client/impl/src/main/java/com/alipay/sofa/registry/client/provider/DirectServerManager.java
@@ -38,7 +38,8 @@ public class DirectServerManager implements ServerManager {
     this.serverNodes = new ArrayList<ServerNode>();
     this.serverNodes.add(
         ServerNodeParser.parse(
-            String.format("%s:%s", config.getRegistryEndpoint(), config.getRegistryEndpoint())));
+            String.format(
+                "%s:%s", config.getRegistryEndpoint(), config.getRegistryEndpointPort())));
   }
 
   @Override

--- a/client/impl/src/test/java/com/alipay/sofa/registry/client/provider/DirectServerManagerTest.java
+++ b/client/impl/src/test/java/com/alipay/sofa/registry/client/provider/DirectServerManagerTest.java
@@ -47,6 +47,7 @@ public class DirectServerManagerTest {
 
     // when
     when(config.getRegistryEndpoint()).thenReturn("127.0.0.1");
+    when(config.getRegistryEndpointPort()).thenReturn(9600);
 
     // then
     ServerManager serverManager = new DirectServerManager(config);

--- a/client/log/pom.xml
+++ b/client/log/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>registry-client-parent</artifactId>
-        <version>6.1.5-SNAPSHOT</version>
+        <version>6.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>registry-parent</artifactId>
-        <version>6.1.5-SNAPSHOT</version>
+        <version>6.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>registry-parent</artifactId>
-        <version>6.1.5-SNAPSHOT</version>
+        <version>6.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.alipay.sofa</groupId>
     <artifactId>registry-parent</artifactId>
-    <version>6.1.5-SNAPSHOT</version>
+    <version>6.1.5</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/server/common/model/pom.xml
+++ b/server/common/model/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>registry-common</artifactId>
-        <version>6.1.5-SNAPSHOT</version>
+        <version>6.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server/common/pom.xml
+++ b/server/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>registry-server-parent</artifactId>
-        <version>6.1.5-SNAPSHOT</version>
+        <version>6.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server/common/util/pom.xml
+++ b/server/common/util/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>registry-common</artifactId>
-        <version>6.1.5-SNAPSHOT</version>
+        <version>6.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server/distribution/all/pom.xml
+++ b/server/distribution/all/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>registry-distribution</artifactId>
-        <version>6.1.5-SNAPSHOT</version>
+        <version>6.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server/distribution/pom.xml
+++ b/server/distribution/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>registry-server-parent</artifactId>
-        <version>6.1.5-SNAPSHOT</version>
+        <version>6.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>registry-parent</artifactId>
-        <version>6.1.5-SNAPSHOT</version>
+        <version>6.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/server/remoting/api/pom.xml
+++ b/server/remoting/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>registry-remoting</artifactId>
-        <version>6.1.5-SNAPSHOT</version>
+        <version>6.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server/remoting/bolt/pom.xml
+++ b/server/remoting/bolt/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>registry-remoting</artifactId>
-        <version>6.1.5-SNAPSHOT</version>
+        <version>6.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server/remoting/http/pom.xml
+++ b/server/remoting/http/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>registry-remoting</artifactId>
-        <version>6.1.5-SNAPSHOT</version>
+        <version>6.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server/remoting/pom.xml
+++ b/server/remoting/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>registry-server-parent</artifactId>
-        <version>6.1.5-SNAPSHOT</version>
+        <version>6.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server/server/data/pom.xml
+++ b/server/server/data/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>registry-server</artifactId>
-        <version>6.1.5-SNAPSHOT</version>
+        <version>6.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server/server/integration/pom.xml
+++ b/server/server/integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>registry-server</artifactId>
-        <version>6.1.5-SNAPSHOT</version>
+        <version>6.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server/server/meta/pom.xml
+++ b/server/server/meta/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>registry-server</artifactId>
-        <version>6.1.5-SNAPSHOT</version>
+        <version>6.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/bootstrap/MetaServerConfiguration.java
+++ b/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/bootstrap/MetaServerConfiguration.java
@@ -399,6 +399,11 @@ public class MetaServerConfiguration {
     public RegistryCoreOpsResource registryCoreOpsResource() {
       return new RegistryCoreOpsResource();
     }
+
+    @Bean
+    public RegistryCoreOpsV2Resource registryCoreOpsV2Resource() {
+      return new RegistryCoreOpsV2Resource();
+    }
   }
 
   @Configuration

--- a/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/RegistryCoreOpsResource.java
+++ b/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/RegistryCoreOpsResource.java
@@ -18,22 +18,15 @@ package com.alipay.sofa.registry.server.meta.resource;
 
 import com.alipay.sofa.registry.common.model.CommonResponse;
 import com.alipay.sofa.registry.common.model.GenericResponse;
-import com.alipay.sofa.registry.common.model.Node.NodeType;
-import com.alipay.sofa.registry.common.model.metaserver.DataOperation;
-import com.alipay.sofa.registry.common.model.metaserver.blacklist.RegistryForbiddenServerRequest;
 import com.alipay.sofa.registry.log.Logger;
 import com.alipay.sofa.registry.log.LoggerFactory;
-import com.alipay.sofa.registry.server.meta.lease.filter.RegistryForbiddenServerManager;
 import com.alipay.sofa.registry.server.meta.resource.filter.LeaderAwareRestController;
-import com.google.common.annotations.VisibleForTesting;
-import javax.ws.rs.FormParam;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import org.apache.commons.lang.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import sun.net.util.IPAddressUtil;
 
 /**
@@ -45,97 +38,43 @@ public class RegistryCoreOpsResource {
 
   private final Logger LOGGER = LoggerFactory.getLogger(RegistryCoreOpsResource.class);
 
-  @Autowired private RegistryForbiddenServerManager registryForbiddenServerManager;
-
+  /**
+   * use /opsapi/v2 instead
+   *
+   * @param ip
+   * @return
+   */
   @PUT
   @Path("/server/group/quit/{ip}")
   @Produces(MediaType.APPLICATION_JSON)
   @LeaderAwareRestController
-  public CommonResponse kickoffServer(
-      @FormParam(value = "cell") String cell,
-      @FormParam(value = "nodeType") String nodeType,
-      @PathParam(value = "ip") String ip) {
-    LOGGER.info("[kickoffServer][begin] server [{}][{}][{}]", cell, nodeType, ip);
-
-    // first time deploy, session and data script not contains cell and app,
-    // default return true, let shutdown trigger quit and join
-    if (StringUtils.isBlank(cell) || StringUtils.isBlank(nodeType)) {
-      return GenericResponse.buildSuccessResponse();
-    }
-    NodeType nodeTypeEnum = NodeType.codeOf(nodeType);
-    if (nodeTypeEnum == null) {
-      return GenericResponse.buildFailedResponse("invalid nodeType: " + nodeType);
-    }
-
+  @Deprecated
+  public CommonResponse kickoffServer(@PathParam(value = "ip") String ip) {
+    LOGGER.warn("[kickoffServer][begin] server [{}], use opsapi/v2 instead", ip);
     if (StringUtils.isBlank(ip) || !IPAddressUtil.isIPv4LiteralAddress(ip)) {
       LOGGER.error("[kickoffServer]invalid ip: {}", ip);
       return GenericResponse.buildFailedResponse("invalid ip address: " + ip);
     }
-    try {
-      boolean success =
-          registryForbiddenServerManager.addToBlacklist(
-              new RegistryForbiddenServerRequest(DataOperation.ADD, nodeTypeEnum, ip, cell));
-
-      if (!success) {
-        LOGGER.error("[kickoffServer] add ip: {} to blacklist fail.", ip);
-      }
-      return success
-          ? GenericResponse.buildSuccessResponse()
-          : GenericResponse.buildFailedResponse("kickoffServer: " + ip + " fail.");
-    } catch (Throwable th) {
-      LOGGER.error("[kickoffServer]", th);
-      return GenericResponse.buildFailedResponse(th.getMessage());
-    } finally {
-      LOGGER.info("[kickoffServer][end] server [{}]", ip);
-    }
+    return GenericResponse.buildSuccessResponse("use opsapi/v2 instead");
   }
 
+  /**
+   * use /opsapi/v2 instead
+   *
+   * @param ip
+   * @return
+   */
   @PUT
   @Path("/server/group/join/{ip}")
   @Produces(MediaType.APPLICATION_JSON)
   @LeaderAwareRestController
-  public CommonResponse rejoinServerGroup(
-      @FormParam(value = "cell") String cell,
-      @FormParam(value = "nodeType") String nodeType,
-      @PathParam(value = "ip") String ip) {
-    LOGGER.info("[rejoinServerGroup][begin] server [{}][{}][{}]", cell, nodeType, ip);
-
-    // first time deploy, session and data script not contains cell and app,
-    // default return true, let shutdown trigger quit and join
-    if (StringUtils.isBlank(cell) || StringUtils.isBlank(nodeType)) {
-      return GenericResponse.buildSuccessResponse();
-    }
-    NodeType nodeTypeEnum = NodeType.codeOf(nodeType);
-    if (nodeType == null) {
-      return GenericResponse.buildFailedResponse("invalid nodeType: " + nodeType);
-    }
-
+  @Deprecated
+  public CommonResponse rejoinServerGroup(@PathParam(value = "ip") String ip) {
+    LOGGER.warn("[rejoinServerGroup][begin] server [{}], use opsapi/v2 instead", ip);
     if (StringUtils.isBlank(ip) || !IPAddressUtil.isIPv4LiteralAddress(ip)) {
       LOGGER.error("[rejoinServerGroup]invalid ip: {}", ip);
       return GenericResponse.buildFailedResponse("invalid ip address: " + ip);
     }
-    try {
-      boolean success =
-          registryForbiddenServerManager.removeFromBlacklist(
-              new RegistryForbiddenServerRequest(DataOperation.REMOVE, nodeTypeEnum, ip, cell));
-      if (!success) {
-        LOGGER.error("[rejoinServerGroup] remove ip: {} to blacklist fail.", ip);
-      }
-      return success
-          ? GenericResponse.buildSuccessResponse()
-          : GenericResponse.buildFailedResponse("rejoinServerGroup: " + ip + " fail.");
-    } catch (Throwable th) {
-      LOGGER.error("[rejoinServerGroup]", th);
-      return GenericResponse.buildFailedResponse(th.getMessage());
-    } finally {
-      LOGGER.info("[rejoinServerGroup][end] server [{}]", ip);
-    }
-  }
-
-  @VisibleForTesting
-  protected RegistryCoreOpsResource setRegistryForbiddenServerManager(
-      RegistryForbiddenServerManager registryForbiddenServerManager) {
-    this.registryForbiddenServerManager = registryForbiddenServerManager;
-    return this;
+    return GenericResponse.buildSuccessResponse("use opsapi/v2 instead");
   }
 }

--- a/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/RegistryCoreOpsV2Resource.java
+++ b/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/RegistryCoreOpsV2Resource.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.registry.server.meta.resource;
+
+import com.alipay.sofa.registry.common.model.CommonResponse;
+import com.alipay.sofa.registry.common.model.GenericResponse;
+import com.alipay.sofa.registry.common.model.Node.NodeType;
+import com.alipay.sofa.registry.common.model.metaserver.DataOperation;
+import com.alipay.sofa.registry.common.model.metaserver.blacklist.RegistryForbiddenServerRequest;
+import com.alipay.sofa.registry.log.Logger;
+import com.alipay.sofa.registry.log.LoggerFactory;
+import com.alipay.sofa.registry.server.meta.lease.filter.RegistryForbiddenServerManager;
+import com.alipay.sofa.registry.server.meta.resource.filter.LeaderAwareRestController;
+import com.google.common.annotations.VisibleForTesting;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import org.apache.commons.lang.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import sun.net.util.IPAddressUtil;
+
+/**
+ * @author chen.zhu
+ *     <p>Mar 24, 2021
+ */
+@Path("opsapi/v2")
+public class RegistryCoreOpsV2Resource {
+
+  private final Logger LOGGER = LoggerFactory.getLogger(RegistryCoreOpsV2Resource.class);
+
+  @Autowired private RegistryForbiddenServerManager registryForbiddenServerManager;
+
+  @PUT
+  @Path("/server/group/quit/{ip}")
+  @Produces(MediaType.APPLICATION_JSON)
+  @LeaderAwareRestController
+  public CommonResponse kickoffServer(
+      @FormParam(value = "cell") String cell,
+      @FormParam(value = "nodeType") String nodeType,
+      @PathParam(value = "ip") String ip) {
+    LOGGER.info("[kickoffServerV2][begin] server [{}][{}][{}]", cell, nodeType, ip);
+
+    if (StringUtils.isBlank(cell) || StringUtils.isBlank(nodeType)) {
+      return GenericResponse.buildFailedResponse("invalid param.");
+    }
+    NodeType nodeTypeEnum = NodeType.codeOf(nodeType);
+    if (nodeTypeEnum == null) {
+      return GenericResponse.buildFailedResponse("invalid nodeType: " + nodeType);
+    }
+
+    if (StringUtils.isBlank(ip) || !IPAddressUtil.isIPv4LiteralAddress(ip)) {
+      LOGGER.error("[kickoffServerV2]invalid ip: {}", ip);
+      return GenericResponse.buildFailedResponse("invalid ip address: " + ip);
+    }
+    try {
+      boolean success =
+          registryForbiddenServerManager.addToBlacklist(
+              new RegistryForbiddenServerRequest(DataOperation.ADD, nodeTypeEnum, ip, cell));
+
+      if (!success) {
+        LOGGER.error("[kickoffServerV2] add ip: {} to blacklist fail.", ip);
+      }
+      return success
+          ? GenericResponse.buildSuccessResponse()
+          : GenericResponse.buildFailedResponse("kickoffServer: " + ip + " fail.");
+    } catch (Throwable th) {
+      LOGGER.error("[kickoffServerV2]", th);
+      return GenericResponse.buildFailedResponse(th.getMessage());
+    } finally {
+      LOGGER.info("[kickoffServerV2][end] server [{}]", ip);
+    }
+  }
+
+  @PUT
+  @Path("/server/group/join/{ip}")
+  @Produces(MediaType.APPLICATION_JSON)
+  @LeaderAwareRestController
+  public CommonResponse rejoinServerGroup(
+      @FormParam(value = "cell") String cell,
+      @FormParam(value = "nodeType") String nodeType,
+      @PathParam(value = "ip") String ip) {
+    LOGGER.info("[rejoinServerGroupV2][begin] server [{}][{}][{}]", cell, nodeType, ip);
+
+    if (StringUtils.isBlank(cell) || StringUtils.isBlank(nodeType)) {
+      return GenericResponse.buildFailedResponse("invalid param.");
+    }
+    NodeType nodeTypeEnum = NodeType.codeOf(nodeType);
+    if (nodeType == null) {
+      return GenericResponse.buildFailedResponse("invalid nodeType: " + nodeType);
+    }
+
+    if (StringUtils.isBlank(ip) || !IPAddressUtil.isIPv4LiteralAddress(ip)) {
+      LOGGER.error("[rejoinServerGroupV2]invalid ip: {}", ip);
+      return GenericResponse.buildFailedResponse("invalid ip address: " + ip);
+    }
+    try {
+      boolean success =
+          registryForbiddenServerManager.removeFromBlacklist(
+              new RegistryForbiddenServerRequest(DataOperation.REMOVE, nodeTypeEnum, ip, cell));
+      if (!success) {
+        LOGGER.error("[rejoinServerGroupV2] remove ip: {} to blacklist fail.", ip);
+      }
+      return success
+          ? GenericResponse.buildSuccessResponse()
+          : GenericResponse.buildFailedResponse("rejoinServerGroup: " + ip + " fail.");
+    } catch (Throwable th) {
+      LOGGER.error("[rejoinServerGroupV2]", th);
+      return GenericResponse.buildFailedResponse(th.getMessage());
+    } finally {
+      LOGGER.info("[rejoinServerGroupV2][end] server [{}]", ip);
+    }
+  }
+
+  @VisibleForTesting
+  protected RegistryCoreOpsV2Resource setRegistryForbiddenServerManager(
+      RegistryForbiddenServerManager registryForbiddenServerManager) {
+    this.registryForbiddenServerManager = registryForbiddenServerManager;
+    return this;
+  }
+}

--- a/server/server/meta/src/test/java/com/alipay/sofa/registry/server/meta/resource/RegistryCoreOpsResourceTest.java
+++ b/server/server/meta/src/test/java/com/alipay/sofa/registry/server/meta/resource/RegistryCoreOpsResourceTest.java
@@ -54,7 +54,7 @@ public class RegistryCoreOpsResourceTest extends AbstractMetaServerTestBase {
 
   @Mock private LeaderElector leaderElector;
 
-  private RegistryCoreOpsResource resource;
+  private RegistryCoreOpsV2Resource resource;
 
   @Before
   public void before() {
@@ -64,7 +64,7 @@ public class RegistryCoreOpsResourceTest extends AbstractMetaServerTestBase {
     when(leaderElector.getLeader()).thenReturn("127.0.0.1");
 
     resource =
-        new RegistryCoreOpsResource()
+        new RegistryCoreOpsV2Resource()
             .setRegistryForbiddenServerManager(registryForbiddenServerManager);
     nodeOperatingService.setProvideDataService(provideDataService);
   }
@@ -87,7 +87,7 @@ public class RegistryCoreOpsResourceTest extends AbstractMetaServerTestBase {
     registryForbiddenServerManager =
         new DefaultForbiddenServerManager(provideDataService, nodeOperatingService);
     resource =
-        new RegistryCoreOpsResource()
+        new RegistryCoreOpsV2Resource()
             .setRegistryForbiddenServerManager(registryForbiddenServerManager);
 
     when(provideDataService.queryProvideData(ValueConstants.REGISTRY_SERVER_BLACK_LIST_DATA_ID))

--- a/server/server/pom.xml
+++ b/server/server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>registry-server-parent</artifactId>
-        <version>6.1.5-SNAPSHOT</version>
+        <version>6.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server/server/session/pom.xml
+++ b/server/server/session/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>registry-server</artifactId>
-        <version>6.1.5-SNAPSHOT</version>
+        <version>6.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server/server/shared/pom.xml
+++ b/server/server/shared/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>registry-server</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>6.1.5-SNAPSHOT</version>
+        <version>6.1.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/server/store/api/pom.xml
+++ b/server/store/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>registry-store</artifactId>
-        <version>6.1.5-SNAPSHOT</version>
+        <version>6.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server/store/jdbc/pom.xml
+++ b/server/store/jdbc/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>registry-store</artifactId>
-        <version>6.1.5-SNAPSHOT</version>
+        <version>6.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/server/store/jraft/pom.xml
+++ b/server/store/jraft/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>registry-store</artifactId>
-        <version>6.1.5-SNAPSHOT</version>
+        <version>6.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/server/store/pom.xml
+++ b/server/store/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>registry-server-parent</artifactId>
-        <version>6.1.5-SNAPSHOT</version>
+        <version>6.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>registry-parent</artifactId>
-        <version>6.1.5-SNAPSHOT</version>
+        <version>6.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
### Motivation:

6.1.4迭代中RegistryCoreOpsResource修改了/server/group/quit/{ip}，meta发布到6.1.4版本后，data,session发布时关流量仍然执行老的url，导致关流量调用报错。

### Modification:

Describe the idea and modifications you've done.

### Result:

Fixes #226 

If there is no issue then describe the changes introduced by this PR.
