### PR TITLE
add tarLongFileMode=posix configuration for maven-assembly-plugin

### DIFF
--- a/server/distribution/all/pom.xml
+++ b/server/distribution/all/pom.xml
@@ -72,6 +72,7 @@
                             <descriptors>
                                 <descriptor>distribution-all.xml</descriptor>
                             </descriptors>
+                            <tarLongFileMode>posix</tarLongFileMode>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
### Motivation:
When I build sofa-registry on Mac Pro, a error encountered:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:3.0.0:single (distribution-session) on project registry-distribution-all: Execution distribution-session of goal org.apache.maven.plugins:maven-assembly-plugin:3.0.0:single failed: group id '707420648' is too big ( > 2097151 ). Use STAR or POSIX extensions to overcome this limit -> [Help 1]
```

### Modification:

add <tarLongFileMode>posix</tarLongFileMode> to Maven assembly plugin configuration.

### Result:

Solved the error.
