### PR TITLE
Explicitly specify spring-boot-maven-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
         <guava-retrying.version>2.0.0</guava-retrying.version>
         <zstd-jni.version>1.3.6-1</zstd-jni.version>
         <log4j2.version>2.17.0</log4j2.version>
+        <spring.boot.version>2.3.9.RELEASE</spring.boot.version>
         <main.user.dir>${user.dir}</main.user.dir>
         <argLine>-Dnetwork_interface_denylist=docker0</argLine>
         <!-- for linke 添加isSkipUT, isSkipIT参数声明，防止编译时产生错误 -->
@@ -100,7 +101,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-parent</artifactId>
-                <version>2.3.9.RELEASE</version>
+                <version>${spring.boot.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -454,7 +455,15 @@
     </dependencyManagement>
 
     <build>
-
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                    <version>${spring.boot.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
### Motivation:
I encountered this error while building on a laptop:
```
[ERROR] Failed to execute goal org.springframework.boot:spring-boot-maven-plugin:3.0.0-M4:repackage (default) on project registry-server-session: Execution default of goal org.springframework.boot:spring-boot-maven-plugin:3.0.0-M4:repackage failed: Unable to load the mojo 'repackage' in the plugin 'org.springframework.boot:spring-boot-maven-plugin:3.0.0-M4' due to an API incompatibility: org.codehaus.plexus.component.repository.exception.ComponentLookupException: org/springframework/boot/maven/RepackageMojo has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 52.0
```
### Modification:

Explicitly specify spring-boot-maven-plugin version

( This error not encountered on another PC. It is odd and it may be environmental. And I think it will not introduce negative effect when explicitly specify spring-boot-maven-plugin version. )

### Result:

Keep the spring-boot-maven-plugin version same to spring boot.
