### PR TITLE
Fix meta/session shutdown.sh bug

### DIFF
--- a/server/distribution/all/bin/meta/shutdown.sh
+++ b/server/distribution/all/bin/meta/shutdown.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-REGISTRY_APP_NAME=meta ../base/shutdown_base.sh
+BASE_DIR=`cd $(dirname $0)/../..; pwd`
+REGISTRY_APP_NAME=meta ${BASE_DIR}/bin/base/shutdown_base.sh

--- a/server/distribution/all/bin/session/shutdown.sh
+++ b/server/distribution/all/bin/session/shutdown.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-REGISTRY_APP_NAME=session ../base/shutdown_base.sh
+BASE_DIR=`cd $(dirname $0)/../..; pwd`
+REGISTRY_APP_NAME=session ${BASE_DIR}/bin/base/shutdown_base.sh


### PR DESCRIPTION
### Motivation:

server/distribution/all/bin/data/shutdown.sh
```
#!/bin/bash

BASE_DIR=`cd $(dirname $0)/../..; pwd`
REGISTRY_APP_NAME=data ${BASE_DIR}/bin/base/shutdown_base.sh
```

But `server/distribution/all/bin/meta/shutdown.sh` and `server/distribution/all/bin/session/shutdown.sh` is like this:
```
#!/bin/bash

REGISTRY_APP_NAME=xxxx ../base/shutdown_base.sh
```
The relative path is not correct.

### Modification:

Fix meta/session shutdown.sh bug

### Result:


