### PR TITLE
Remove sofa common util stringutil usage

### DIFF
--- a/server/server/data/src/main/java/com/alipay/sofa/registry/server/data/providedata/CompressDatumService.java
+++ b/server/server/data/src/main/java/com/alipay/sofa/registry/server/data/providedata/CompressDatumService.java
@@ -16,7 +16,6 @@
  */
 package com.alipay.sofa.registry.server.data.providedata;
 
-import com.alipay.sofa.common.profile.StringUtil;
 import com.alipay.sofa.registry.common.model.constants.ValueConstants;
 import com.alipay.sofa.registry.common.model.metaserver.CompressDatumSwitch;
 import com.alipay.sofa.registry.common.model.metaserver.CompressPushSwitch;
@@ -30,6 +29,7 @@ import com.alipay.sofa.registry.server.data.bootstrap.DataServerConfig;
 import com.alipay.sofa.registry.server.shared.providedata.AbstractFetchSystemPropertyService;
 import com.alipay.sofa.registry.server.shared.providedata.SystemDataStorage;
 import com.alipay.sofa.registry.util.JsonUtils;
+import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class CompressDatumService
@@ -52,7 +52,7 @@ public class CompressDatumService
   @Override
   protected boolean doProcess(CompressStorage expect, ProvideData data) {
     final String switchString = ProvideData.toString(data);
-    if (StringUtil.isBlank(switchString)) {
+    if (StringUtils.isBlank(switchString)) {
       LOGGER.info("Fetch compress datum switch content empty");
       return true;
     }

--- a/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/bootstrap/MetaServerBootstrap.java
+++ b/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/bootstrap/MetaServerBootstrap.java
@@ -16,7 +16,6 @@
  */
 package com.alipay.sofa.registry.server.meta.bootstrap;
 
-import com.alipay.sofa.common.profile.StringUtil;
 import com.alipay.sofa.registry.common.model.elector.LeaderInfo;
 import com.alipay.sofa.registry.common.model.store.URL;
 import com.alipay.sofa.registry.log.Logger;
@@ -178,7 +177,7 @@ public class MetaServerBootstrap {
                 "[MetaBootstrap] retry connect to meta leader: {}, client:{}",
                 leader.getLeader(),
                 localMetaExchanger.getClient());
-            return StringUtil.isNotEmpty(leader.getLeader())
+            return StringUtils.isNotEmpty(leader.getLeader())
                 && localMetaExchanger.getClient() != null;
           });
 

--- a/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/remoting/meta/MetaNodeExchange.java
+++ b/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/remoting/meta/MetaNodeExchange.java
@@ -32,7 +32,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 

--- a/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/remoting/meta/MetaNodeExchange.java
+++ b/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/remoting/meta/MetaNodeExchange.java
@@ -16,7 +16,6 @@
  */
 package com.alipay.sofa.registry.server.meta.remoting.meta;
 
-import com.alipay.sofa.common.profile.StringUtil;
 import com.alipay.sofa.registry.common.model.store.URL;
 import com.alipay.sofa.registry.log.Logger;
 import com.alipay.sofa.registry.log.LoggerFactory;
@@ -33,6 +32,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -77,12 +78,12 @@ public class MetaNodeExchange extends ClientSideExchanger {
 
   public Response sendRequest(Object requestBody) throws RequestException {
     final String newLeader = metaLeaderService.getLeader();
-    if (StringUtil.isBlank(newLeader)) {
+    if (StringUtils.isBlank(newLeader)) {
       LOGGER.error("[sendRequest] meta leader is empty.");
       return () -> ResultStatus.FAILED;
     }
 
-    if (!StringUtil.equals(metaLeader, newLeader) || boltExchange.getClient(serverType) == null) {
+    if (!StringUtils.equals(metaLeader, newLeader) || boltExchange.getClient(serverType) == null) {
       setLeaderAndConnect(newLeader);
     }
 

--- a/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/HealthResource.java
+++ b/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/HealthResource.java
@@ -16,7 +16,6 @@
  */
 package com.alipay.sofa.registry.server.meta.resource;
 
-import com.alipay.sofa.common.profile.StringUtil;
 import com.alipay.sofa.registry.common.model.CommonResponse;
 import com.alipay.sofa.registry.metrics.ReporterUtils;
 import com.alipay.sofa.registry.server.meta.MetaLeaderService;
@@ -33,6 +32,8 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
+
+import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -93,7 +94,7 @@ public class HealthResource {
     ret = ret && start;
     sb.append(", remoteMetaRegisterServerStart:").append(start);
 
-    boolean leaderNotEmpty = StringUtil.isNotBlank(metaLeaderService.getLeader());
+    boolean leaderNotEmpty = StringUtils.isNotBlank(metaLeaderService.getLeader());
     ret = ret && leaderNotEmpty;
 
     sb.append(", role:").append(metaLeaderService.amILeader() ? "leader" : "follower");

--- a/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/HealthResource.java
+++ b/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/HealthResource.java
@@ -32,7 +32,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
-
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 

--- a/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/providedata/CompressPushService.java
+++ b/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/providedata/CompressPushService.java
@@ -16,7 +16,6 @@
  */
 package com.alipay.sofa.registry.server.session.providedata;
 
-import com.alipay.sofa.common.profile.StringUtil;
 import com.alipay.sofa.registry.common.model.constants.ValueConstants;
 import com.alipay.sofa.registry.common.model.metaserver.CompressPushSwitch;
 import com.alipay.sofa.registry.common.model.metaserver.ProvideData;
@@ -55,7 +54,7 @@ public class CompressPushService
   @Override
   protected boolean doProcess(CompressStorage expect, ProvideData data) {
     final String switchString = ProvideData.toString(data);
-    if (StringUtil.isBlank(switchString)) {
+    if (StringUtils.isBlank(switchString)) {
       LOGGER.info("Fetch session push compressed enabled content empty");
       return true;
     }

--- a/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/providedata/FetchPushEfficiencyConfigService.java
+++ b/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/providedata/FetchPushEfficiencyConfigService.java
@@ -118,7 +118,8 @@ public class FetchPushEfficiencyConfigService
   }
 
   @VisibleForTesting
-  public FetchPushEfficiencyConfigService setSessionServerConfig(SessionServerConfig sessionServerConfig){
+  public FetchPushEfficiencyConfigService setSessionServerConfig(
+      SessionServerConfig sessionServerConfig) {
     this.sessionServerConfig = sessionServerConfig;
     return this;
   }

--- a/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/push/PushEfficiencyImproveConfig.java
+++ b/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/push/PushEfficiencyImproveConfig.java
@@ -20,7 +20,6 @@ import com.alipay.sofa.registry.net.NetUtil;
 import com.alipay.sofa.registry.server.session.bootstrap.SessionServerConfig;
 import java.util.HashSet;
 import java.util.Set;
-
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 
@@ -73,14 +72,13 @@ public class PushEfficiencyImproveConfig {
 
   /** 三板斧配置 支持 按订阅方应用 设置 时间 */
   private Set<String> subAppSet = new HashSet<>();
-  /** 三板斧配置 支持 按订阅方应用 设置 pushTask wake  默认false */
+  /** 三板斧配置 支持 按订阅方应用 设置 pushTask wake 默认false */
   private boolean pushTaskWake = false;
-  /** 三板斧配置 支持 按订阅方应用 设置 regWorkTask wake 默认 reg wakeup true*/
+  /** 三板斧配置 支持 按订阅方应用 设置 regWorkTask wake 默认 reg wakeup true */
   private boolean regWorkWake = true;
 
   /** session 处理 pushTask delay pushTaskDebouncingMillis 时间处理，可以合并相同的推送任务，避免数据连续变化触发大量推送, 默认500ms */
   private int sbfAppPushTaskDebouncingMillis = DEFAULT_PUSH_TASK_DEBOUNCING_MILLIS;
-
 
   /**
    * 判断是否满足 三板斧灰度条件
@@ -106,7 +104,7 @@ public class PushEfficiencyImproveConfig {
    * @return
    */
   public boolean inAppSBF(String appName) {
-    if(CollectionUtils.isNotEmpty(subAppSet) && subAppSet.contains(ALL_APP)){
+    if (CollectionUtils.isNotEmpty(subAppSet) && subAppSet.contains(ALL_APP)) {
       return true;
     }
     if (CollectionUtils.isNotEmpty(subAppSet) && subAppSet.contains(appName)) {
@@ -253,7 +251,8 @@ public class PushEfficiencyImproveConfig {
   }
 
   public void setSessionServerConfig(SessionServerConfig sessionServerConfig) {
-    if (null != sessionServerConfig && StringUtils.isNotBlank(sessionServerConfig.getSessionServerRegion())) {
+    if (null != sessionServerConfig
+        && StringUtils.isNotBlank(sessionServerConfig.getSessionServerRegion())) {
       this.CURRENT_ZONE = sessionServerConfig.getSessionServerRegion().toUpperCase();
       this.DEFAULT_CHANGE_DEBOUNCING_MILLIS = sessionServerConfig.getDataChangeDebouncingMillis();
       this.DEFAULT_CHANGE_DEBOUNCING_MAX_MILLIS =

--- a/server/server/session/src/test/java/com/alipay/sofa/registry/server/session/providedata/FetchPushEfficiencyConfigServiceTest.java
+++ b/server/server/session/src/test/java/com/alipay/sofa/registry/server/session/providedata/FetchPushEfficiencyConfigServiceTest.java
@@ -51,21 +51,18 @@ public class FetchPushEfficiencyConfigServiceTest {
   public void test() {
     Assert.assertTrue(fetchPushEfficiencyConfigService.getSystemPropertyIntervalMillis() == 0);
     Assert.assertTrue(
-            fetchPushEfficiencyConfigService.doProcess(
-                    fetchPushEfficiencyConfigService.getStorage().get(),
-                    new ProvideData(
-                            new ServerDataBox(
-                                    ""),
-                            ValueConstants.CHANGE_PUSH_TASK_DELAY_CONFIG_DATA_ID,
-                            0L)));
+        fetchPushEfficiencyConfigService.doProcess(
+            fetchPushEfficiencyConfigService.getStorage().get(),
+            new ProvideData(
+                new ServerDataBox(""), ValueConstants.CHANGE_PUSH_TASK_DELAY_CONFIG_DATA_ID, 0L)));
     Assert.assertFalse(
-            fetchPushEfficiencyConfigService.doProcess(
-                    new FetchPushEfficiencyConfigService.SwitchStorage(0L, null),
-                    new ProvideData(
-                            new ServerDataBox(
-                                    "{\"changeDebouncingMillis\":1000,\"changeDebouncingMaxMillis\":3000,\"changeTaskWaitingMillis\":100,\"pushTaskWaitingMillis\":0,\"pushTaskDebouncingMillis\":500,\"regWorkWaitingMillis\":200,\"zoneSet\":[\"ALL_ZONE\"]}"),
-                            ValueConstants.CHANGE_PUSH_TASK_DELAY_CONFIG_DATA_ID,
-                            0L)));
+        fetchPushEfficiencyConfigService.doProcess(
+            new FetchPushEfficiencyConfigService.SwitchStorage(0L, null),
+            new ProvideData(
+                new ServerDataBox(
+                    "{\"changeDebouncingMillis\":1000,\"changeDebouncingMaxMillis\":3000,\"changeTaskWaitingMillis\":100,\"pushTaskWaitingMillis\":0,\"pushTaskDebouncingMillis\":500,\"regWorkWaitingMillis\":200,\"zoneSet\":[\"ALL_ZONE\"]}"),
+                ValueConstants.CHANGE_PUSH_TASK_DELAY_CONFIG_DATA_ID,
+                0L)));
 
     Assert.assertFalse(
         fetchPushEfficiencyConfigService.doProcess(
@@ -84,62 +81,62 @@ public class FetchPushEfficiencyConfigServiceTest {
                 ValueConstants.CHANGE_PUSH_TASK_DELAY_CONFIG_DATA_ID,
                 2L)));
     Assert.assertFalse(
-            fetchPushEfficiencyConfigService.doProcess(
-                    fetchPushEfficiencyConfigService.getStorage().get(),
-                    new ProvideData(
-                            new ServerDataBox(
-                                    "{\"changeDebouncingMillis\":100,\"changeDebouncingMaxMillis\":1000,\"changeTaskWaitingMillis\":50,\"pushTaskWaitingMillis\":50,\"pushTaskDebouncingMillis\":10,\"regWorkWaitingMillis\":100,\"ipSet\":[\"127.0.0.1\"]}"),
-                            ValueConstants.CHANGE_PUSH_TASK_DELAY_CONFIG_DATA_ID,
-                            5L)));
+        fetchPushEfficiencyConfigService.doProcess(
+            fetchPushEfficiencyConfigService.getStorage().get(),
+            new ProvideData(
+                new ServerDataBox(
+                    "{\"changeDebouncingMillis\":100,\"changeDebouncingMaxMillis\":1000,\"changeTaskWaitingMillis\":50,\"pushTaskWaitingMillis\":50,\"pushTaskDebouncingMillis\":10,\"regWorkWaitingMillis\":100,\"ipSet\":[\"127.0.0.1\"]}"),
+                ValueConstants.CHANGE_PUSH_TASK_DELAY_CONFIG_DATA_ID,
+                5L)));
     Assert.assertTrue(
-            fetchPushEfficiencyConfigService
-                    .getStorage()
-                    .get()
-                    .pushEfficiencyImproveConfig
-                    .getChangeDebouncingMillis()
-                    == 1000);
+        fetchPushEfficiencyConfigService
+                .getStorage()
+                .get()
+                .pushEfficiencyImproveConfig
+                .getChangeDebouncingMillis()
+            == 1000);
     Assert.assertTrue(
-            fetchPushEfficiencyConfigService
-                    .getStorage()
-                    .get()
-                    .pushEfficiencyImproveConfig
-                    .getChangeDebouncingMaxMillis()
-                    == 3000);
+        fetchPushEfficiencyConfigService
+                .getStorage()
+                .get()
+                .pushEfficiencyImproveConfig
+                .getChangeDebouncingMaxMillis()
+            == 3000);
     Assert.assertTrue(
-            fetchPushEfficiencyConfigService
-                    .getStorage()
-                    .get()
-                    .pushEfficiencyImproveConfig
-                    .getChangeTaskWaitingMillis()
-                    == 100);
+        fetchPushEfficiencyConfigService
+                .getStorage()
+                .get()
+                .pushEfficiencyImproveConfig
+                .getChangeTaskWaitingMillis()
+            == 100);
     Assert.assertTrue(
-            fetchPushEfficiencyConfigService
-                    .getStorage()
-                    .get()
-                    .pushEfficiencyImproveConfig
-                    .getPushTaskWaitingMillis()
-                    == 200);
+        fetchPushEfficiencyConfigService
+                .getStorage()
+                .get()
+                .pushEfficiencyImproveConfig
+                .getPushTaskWaitingMillis()
+            == 200);
     Assert.assertTrue(
-            fetchPushEfficiencyConfigService
-                    .getStorage()
-                    .get()
-                    .pushEfficiencyImproveConfig
-                    .getPushTaskDebouncingMillis()
-                    == 500);
+        fetchPushEfficiencyConfigService
+                .getStorage()
+                .get()
+                .pushEfficiencyImproveConfig
+                .getPushTaskDebouncingMillis()
+            == 500);
     Assert.assertTrue(
-            fetchPushEfficiencyConfigService
-                    .getStorage()
-                    .get()
-                    .pushEfficiencyImproveConfig
-                    .getRegWorkWaitingMillis()
-                    == 200);
+        fetchPushEfficiencyConfigService
+                .getStorage()
+                .get()
+                .pushEfficiencyImproveConfig
+                .getRegWorkWaitingMillis()
+            == 200);
     Assert.assertTrue(
-            fetchPushEfficiencyConfigService
-                    .getStorage()
-                    .get()
-                    .pushEfficiencyImproveConfig
-                    .getSbfAppPushTaskDebouncingMillis()
-                    == 500);
+        fetchPushEfficiencyConfigService
+                .getStorage()
+                .get()
+                .pushEfficiencyImproveConfig
+                .getSbfAppPushTaskDebouncingMillis()
+            == 500);
 
     Assert.assertTrue(
         fetchPushEfficiencyConfigService.doProcess(

--- a/server/server/session/src/test/java/com/alipay/sofa/registry/server/session/push/ChangeProcessorTest.java
+++ b/server/server/session/src/test/java/com/alipay/sofa/registry/server/session/push/ChangeProcessorTest.java
@@ -24,7 +24,6 @@ import com.alipay.sofa.registry.server.session.push.ChangeProcessor.Worker;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -144,24 +143,22 @@ public class ChangeProcessorTest {
     configBean.setDataChangeMaxDebouncingMillis(300);
     processor.init();
     Worker[] localWorkers =
-            processor.dataCenterWorkers.get(configBean.getSessionServerDataCenter());
+        processor.dataCenterWorkers.get(configBean.getSessionServerDataCenter());
     Assert.assertEquals(
-            localWorkers.length, processor.sessionServerConfig.getDataChangeFetchTaskWorkerSize());
+        localWorkers.length, processor.sessionServerConfig.getDataChangeFetchTaskWorkerSize());
     ChangeProcessor.Worker worker = localWorkers[0];
     Assert.assertEquals(
-            worker.changeDebouncingMillis,
-            processor.sessionServerConfig.getDataChangeDebouncingMillis());
+        worker.changeDebouncingMillis,
+        processor.sessionServerConfig.getDataChangeDebouncingMillis());
     Assert.assertEquals(
-            worker.changeDebouncingMaxMillis,
-            processor.sessionServerConfig.getDataChangeMaxDebouncingMillis());
+        worker.changeDebouncingMaxMillis,
+        processor.sessionServerConfig.getDataChangeMaxDebouncingMillis());
     PushEfficiencyImproveConfig pushEfficiencyImproveConfig = new PushEfficiencyImproveConfig();
     pushEfficiencyImproveConfig.setChangeDebouncingMillis(10);
     Set<String> zones = new HashSet<>();
     zones.add("ALL_ZONE");
     pushEfficiencyImproveConfig.setZoneSet(zones);
     processor.setWorkDelayTime(pushEfficiencyImproveConfig);
-    Assert.assertEquals(
-            worker.changeDebouncingMillis,
-            10);
+    Assert.assertEquals(worker.changeDebouncingMillis, 10);
   }
 }

--- a/server/server/session/src/test/java/com/alipay/sofa/registry/server/session/push/PushEfficiencyImproveConfigTest.java
+++ b/server/server/session/src/test/java/com/alipay/sofa/registry/server/session/push/PushEfficiencyImproveConfigTest.java
@@ -1,14 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alipay.sofa.registry.server.session.push;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.alipay.sofa.registry.server.session.TestUtils;
 import com.alipay.sofa.registry.server.session.bootstrap.SessionServerConfigBean;
-import org.junit.Assert;
-import org.junit.jupiter.api.Test;
-
 import java.util.HashSet;
 import java.util.Set;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author jiangcun.hlc@antfin.com
@@ -16,45 +31,45 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class PushEfficiencyImproveConfigTest {
 
-    @Test
-    void inIpZoneSBF() {
-        PushEfficiencyImproveConfig pushEfficiencyImproveConfig = new PushEfficiencyImproveConfig();
-        Assert.assertFalse(pushEfficiencyImproveConfig.inIpZoneSBF());
-        Set<String> zones = new HashSet<>();
-        zones.add("ALL_ZONE");
-        pushEfficiencyImproveConfig.setZoneSet(zones);
-        Assert.assertTrue(pushEfficiencyImproveConfig.inIpZoneSBF());
+  @Test
+  void inIpZoneSBF() {
+    PushEfficiencyImproveConfig pushEfficiencyImproveConfig = new PushEfficiencyImproveConfig();
+    Assert.assertFalse(pushEfficiencyImproveConfig.inIpZoneSBF());
+    Set<String> zones = new HashSet<>();
+    zones.add("ALL_ZONE");
+    pushEfficiencyImproveConfig.setZoneSet(zones);
+    Assert.assertTrue(pushEfficiencyImproveConfig.inIpZoneSBF());
 
-        zones = new HashSet<>();
-        zones.add("DEF_ZONE");
-        SessionServerConfigBean configBean = TestUtils.newSessionConfig("testDc");
-        pushEfficiencyImproveConfig.setZoneSet(zones);
-        pushEfficiencyImproveConfig.setSessionServerConfig(configBean);
-        Assert.assertTrue(pushEfficiencyImproveConfig.inIpZoneSBF());
+    zones = new HashSet<>();
+    zones.add("DEF_ZONE");
+    SessionServerConfigBean configBean = TestUtils.newSessionConfig("testDc");
+    pushEfficiencyImproveConfig.setZoneSet(zones);
+    pushEfficiencyImproveConfig.setSessionServerConfig(configBean);
+    Assert.assertTrue(pushEfficiencyImproveConfig.inIpZoneSBF());
 
-        Assert.assertFalse(pushEfficiencyImproveConfig.inAppSBF("testSub"));
+    Assert.assertFalse(pushEfficiencyImproveConfig.inAppSBF("testSub"));
 
+    Set<String> appSet = new HashSet<>();
+    appSet.add("ALL_APP");
+    pushEfficiencyImproveConfig.setSubAppSet(appSet);
+    Assert.assertTrue(pushEfficiencyImproveConfig.inAppSBF("testSub2"));
 
-        Set<String> appSet = new HashSet<>();
-        appSet.add("ALL_APP");
-        pushEfficiencyImproveConfig.setSubAppSet(appSet);
-        Assert.assertTrue(pushEfficiencyImproveConfig.inAppSBF("testSub2"));
+    appSet = new HashSet<>();
+    appSet.add("testSub");
+    pushEfficiencyImproveConfig.setSubAppSet(appSet);
 
-        appSet = new HashSet<>();
-        appSet.add("testSub");
-        pushEfficiencyImproveConfig.setSubAppSet(appSet);
-
-        Assert.assertTrue(pushEfficiencyImproveConfig.inAppSBF("testSub"));
-        Assert.assertTrue(pushEfficiencyImproveConfig.fetchSbfAppPushTaskDebouncingMillis("testSub") > 0);
-        Assert.assertTrue(pushEfficiencyImproveConfig.fetchSbfAppPushTaskDebouncingMillis("testSub2") > 0);
-        Assert.assertFalse(pushEfficiencyImproveConfig.fetchPushTaskWake("testSub"));
-        Assert.assertTrue(pushEfficiencyImproveConfig.fetchRegWorkWake("testSub"));
-        Assert.assertFalse(pushEfficiencyImproveConfig.fetchPushTaskWake("testSub2"));
-        Assert.assertTrue(pushEfficiencyImproveConfig.fetchRegWorkWake("testSub2"));
-        pushEfficiencyImproveConfig.setPushTaskWake(true);
-        pushEfficiencyImproveConfig.setRegWorkWake(false);
-        Assert.assertTrue(pushEfficiencyImproveConfig.fetchPushTaskWake("testSub"));
-        Assert.assertFalse(pushEfficiencyImproveConfig.fetchRegWorkWake("testSub"));
-
-    }
+    Assert.assertTrue(pushEfficiencyImproveConfig.inAppSBF("testSub"));
+    Assert.assertTrue(
+        pushEfficiencyImproveConfig.fetchSbfAppPushTaskDebouncingMillis("testSub") > 0);
+    Assert.assertTrue(
+        pushEfficiencyImproveConfig.fetchSbfAppPushTaskDebouncingMillis("testSub2") > 0);
+    Assert.assertFalse(pushEfficiencyImproveConfig.fetchPushTaskWake("testSub"));
+    Assert.assertTrue(pushEfficiencyImproveConfig.fetchRegWorkWake("testSub"));
+    Assert.assertFalse(pushEfficiencyImproveConfig.fetchPushTaskWake("testSub2"));
+    Assert.assertTrue(pushEfficiencyImproveConfig.fetchRegWorkWake("testSub2"));
+    pushEfficiencyImproveConfig.setPushTaskWake(true);
+    pushEfficiencyImproveConfig.setRegWorkWake(false);
+    Assert.assertTrue(pushEfficiencyImproveConfig.fetchPushTaskWake("testSub"));
+    Assert.assertFalse(pushEfficiencyImproveConfig.fetchRegWorkWake("testSub"));
+  }
 }

--- a/server/server/session/src/test/java/com/alipay/sofa/registry/server/session/push/PushProcessorTest.java
+++ b/server/server/session/src/test/java/com/alipay/sofa/registry/server/session/push/PushProcessorTest.java
@@ -528,7 +528,7 @@ public class PushProcessorTest {
   }
 
   @Test
-  public void testSetPushDelay(){
+  public void testSetPushDelay() {
     PushProcessor processor = newProcessor();
 
     PushEfficiencyImproveConfig pushEfficiencyImproveConfig = new PushEfficiencyImproveConfig();
@@ -539,6 +539,5 @@ public class PushProcessorTest {
     processor.setPushTaskDelayTime(pushEfficiencyImproveConfig);
 
     Assert.assertTrue(processor.taskBuffer.workers[0].getWaitingMillis() == 10);
-
   }
 }

--- a/server/server/shared/src/main/java/com/alipay/sofa/registry/server/shared/util/PersistenceDataParser.java
+++ b/server/server/shared/src/main/java/com/alipay/sofa/registry/server/shared/util/PersistenceDataParser.java
@@ -16,10 +16,10 @@
  */
 package com.alipay.sofa.registry.server.shared.util;
 
-import com.alipay.sofa.common.profile.StringUtil;
 import com.alipay.sofa.registry.common.model.console.PersistenceData;
 import com.alipay.sofa.registry.store.api.DBResponse;
 import com.alipay.sofa.registry.store.api.OperationStatus;
+import org.apache.commons.lang.StringUtils;
 
 /**
  * @author xiaojian.xj
@@ -29,7 +29,7 @@ public class PersistenceDataParser {
 
   public static boolean parse2BoolIgnoreCase(
       PersistenceData persistenceData, boolean defaultValue) {
-    if (persistenceData == null || StringUtil.isBlank(persistenceData.getData())) {
+    if (persistenceData == null || StringUtils.isBlank(persistenceData.getData())) {
       return defaultValue;
     }
     return Boolean.parseBoolean(persistenceData.getData());

--- a/server/store/api/src/main/java/com/alipay/sofa/registry/store/api/elector/AbstractLeaderElector.java
+++ b/server/store/api/src/main/java/com/alipay/sofa/registry/store/api/elector/AbstractLeaderElector.java
@@ -23,11 +23,10 @@ import com.alipay.sofa.registry.util.ConcurrentUtils;
 import com.alipay.sofa.registry.util.LoopRunnable;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
-import org.apache.commons.lang.StringUtils;
-
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.PostConstruct;
+import org.apache.commons.lang.StringUtils;
 
 /**
  * @author chen.zhu

--- a/server/store/api/src/main/java/com/alipay/sofa/registry/store/api/elector/AbstractLeaderElector.java
+++ b/server/store/api/src/main/java/com/alipay/sofa/registry/store/api/elector/AbstractLeaderElector.java
@@ -16,7 +16,6 @@
  */
 package com.alipay.sofa.registry.store.api.elector;
 
-import com.alipay.sofa.common.profile.StringUtil;
 import com.alipay.sofa.registry.log.Logger;
 import com.alipay.sofa.registry.log.LoggerFactory;
 import com.alipay.sofa.registry.net.NetUtil;
@@ -24,6 +23,8 @@ import com.alipay.sofa.registry.util.ConcurrentUtils;
 import com.alipay.sofa.registry.util.LoopRunnable;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
+import org.apache.commons.lang.StringUtils;
+
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.PostConstruct;
@@ -152,7 +153,7 @@ public abstract class AbstractLeaderElector implements LeaderElector {
   }
 
   protected boolean amILeader(String leader) {
-    return StringUtil.equals(myself(), leader) && leaderNotExpired();
+    return StringUtils.equals(myself(), leader) && leaderNotExpired();
   }
 
   private boolean leaderNotExpired() {

--- a/server/store/jdbc/src/main/java/com/alipay/sofa/registry/jdbc/convertor/AppRevisionDomainConvertor.java
+++ b/server/store/jdbc/src/main/java/com/alipay/sofa/registry/jdbc/convertor/AppRevisionDomainConvertor.java
@@ -16,7 +16,6 @@
  */
 package com.alipay.sofa.registry.jdbc.convertor;
 
-import com.alipay.sofa.common.profile.StringUtil;
 import com.alipay.sofa.registry.common.model.store.AppRevision;
 import com.alipay.sofa.registry.core.model.AppRevisionInterface;
 import com.alipay.sofa.registry.jdbc.domain.AppRevisionDomain;
@@ -24,6 +23,8 @@ import com.alipay.sofa.registry.util.JsonUtils;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.*;
+
+import org.apache.commons.lang.StringUtils;
 import org.springframework.util.CollectionUtils;
 
 /**
@@ -75,7 +76,7 @@ public class AppRevisionDomainConvertor {
     appRevision.setBaseParams(JsonUtils.read(domain.getBaseParams(), BASE_FORMAT));
 
     String serviceParams = domain.getServiceParamsLarge();
-    if (StringUtil.isBlank(serviceParams)) {
+    if (StringUtils.isBlank(serviceParams)) {
       serviceParams = domain.getServiceParams();
     }
     appRevision.setInterfaceMap(JsonUtils.read(serviceParams, SERVICE_FORMAT));

--- a/server/store/jdbc/src/main/java/com/alipay/sofa/registry/jdbc/convertor/AppRevisionDomainConvertor.java
+++ b/server/store/jdbc/src/main/java/com/alipay/sofa/registry/jdbc/convertor/AppRevisionDomainConvertor.java
@@ -23,7 +23,6 @@ import com.alipay.sofa.registry.util.JsonUtils;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.*;
-
 import org.apache.commons.lang.StringUtils;
 import org.springframework.util.CollectionUtils;
 


### PR DESCRIPTION
Using apache common-langs StringUtils instead of sofa-common-util's StringUtil under profile package, sofa-common-utils's StringUtil under profile package is removed from newer sofa-common-util version.