### PR TITLE
Remove log4j2 Strings import && bump commons-lang to commons-lang3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <bolt.version>1.6.3</bolt.version>
-        <commons.lang.version>2.6</commons.lang.version>
+        <commons-lang3.version>3.14.0</commons-lang3.version>
         <google.guava.version>18.0</google.guava.version>
         <sofa.common.tools.version>1.0.12</sofa.common.tools.version>
         <junit.version>4.12</junit.version>
@@ -216,9 +216,9 @@
                 <version>${google.guava.version}</version>
             </dependency>
             <dependency>
-                <groupId>commons-lang</groupId>
-                <artifactId>commons-lang</artifactId>
-                <version>${commons.lang.version}</version>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commons-lang3.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.alipay.sofa</groupId>

--- a/server/common/model/src/main/java/com/alipay/sofa/registry/common/model/CollectionSdks.java
+++ b/server/common/model/src/main/java/com/alipay/sofa/registry/common/model/CollectionSdks.java
@@ -20,7 +20,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.util.List;
 import java.util.Set;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author xiaojian.xj

--- a/server/common/model/src/main/java/com/alipay/sofa/registry/common/model/DataUtils.java
+++ b/server/common/model/src/main/java/com/alipay/sofa/registry/common/model/DataUtils.java
@@ -23,7 +23,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.glassfish.jersey.internal.guava.Sets;
 
 public final class DataUtils {

--- a/server/common/model/src/main/java/com/alipay/sofa/registry/common/model/Node.java
+++ b/server/common/model/src/main/java/com/alipay/sofa/registry/common/model/Node.java
@@ -18,7 +18,7 @@ package com.alipay.sofa.registry.common.model;
 
 import com.alipay.sofa.registry.common.model.store.URL;
 import java.io.Serializable;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author shangyu.wh

--- a/server/common/model/src/main/java/com/alipay/sofa/registry/common/model/console/CircuitBreakerData.java
+++ b/server/common/model/src/main/java/com/alipay/sofa/registry/common/model/console/CircuitBreakerData.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.google.common.collect.Sets;
 import java.util.Set;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CircuitBreakerData {

--- a/server/common/model/src/main/java/com/alipay/sofa/registry/common/model/metaserver/ProvideData.java
+++ b/server/common/model/src/main/java/com/alipay/sofa/registry/common/model/metaserver/ProvideData.java
@@ -18,7 +18,7 @@ package com.alipay.sofa.registry.common.model.metaserver;
 
 import com.alipay.sofa.registry.common.model.ServerDataBox;
 import java.io.Serializable;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.util.Assert;
 
 /**

--- a/server/common/model/src/main/java/com/alipay/sofa/registry/common/model/store/Subscriber.java
+++ b/server/common/model/src/main/java/com/alipay/sofa/registry/common/model/store/Subscriber.java
@@ -27,8 +27,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.util.CollectionUtils;
 
 /**

--- a/server/common/util/pom.xml
+++ b/server/common/util/pom.xml
@@ -68,8 +68,8 @@
             <artifactId>jersey-media-json-jackson</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
 
         <dependency>

--- a/server/common/util/src/main/java/com/alipay/sofa/registry/compress/CompressUtils.java
+++ b/server/common/util/src/main/java/com/alipay/sofa/registry/compress/CompressUtils.java
@@ -25,8 +25,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.util.Assert;
 
 public final class CompressUtils {

--- a/server/common/util/src/main/java/com/alipay/sofa/registry/net/NetUtil.java
+++ b/server/common/util/src/main/java/com/alipay/sofa/registry/net/NetUtil.java
@@ -30,7 +30,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.util.CollectionUtils;
 
 /**

--- a/server/common/util/src/main/java/com/alipay/sofa/registry/util/DatumVersionUtil.java
+++ b/server/common/util/src/main/java/com/alipay/sofa/registry/util/DatumVersionUtil.java
@@ -19,7 +19,7 @@ package com.alipay.sofa.registry.util;
 import com.alipay.sofa.registry.log.Logger;
 import com.alipay.sofa.registry.log.LoggerFactory;
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * generates ID: 49 bit millisecond timestamp + 15 bit incremental ID

--- a/server/common/util/src/main/java/com/alipay/sofa/registry/util/ParaCheckUtil.java
+++ b/server/common/util/src/main/java/com/alipay/sofa/registry/util/ParaCheckUtil.java
@@ -20,7 +20,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author qian.lqlq

--- a/server/common/util/src/main/java/com/alipay/sofa/registry/util/PropertySplitter.java
+++ b/server/common/util/src/main/java/com/alipay/sofa/registry/util/PropertySplitter.java
@@ -19,7 +19,7 @@ package com.alipay.sofa.registry.util;
 import com.google.common.base.Splitter;
 import java.util.*;
 import java.util.Map.Entry;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author shangyu.wh

--- a/server/common/util/src/main/java/com/alipay/sofa/registry/util/SystemUtils.java
+++ b/server/common/util/src/main/java/com/alipay/sofa/registry/util/SystemUtils.java
@@ -16,7 +16,7 @@
  */
 package com.alipay.sofa.registry.util;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public final class SystemUtils {
   private SystemUtils() {}

--- a/server/common/util/src/main/java/org/apache/logging/log4j/core/async/Hack.java
+++ b/server/common/util/src/main/java/org/apache/logging/log4j/core/async/Hack.java
@@ -22,10 +22,10 @@ import com.alipay.sofa.registry.util.ConcurrentUtils;
 import com.alipay.sofa.registry.util.LoopRunnable;
 import com.google.common.collect.Maps;
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
-import org.apache.commons.lang.reflect.FieldUtils;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.slf4j.Log4jLogger;
 
@@ -43,8 +43,18 @@ public final class Hack {
     Field fieldLogger = null;
     Field fieldDisruptor = null;
     try {
-      fieldLogger = FieldUtils.getField(Log4jLogger.class, "logger", true);
-      fieldDisruptor = FieldUtils.getField(AsyncLogger.class, "loggerDisruptor", true);
+      Class<?> log4jLoggerSuperCls = Log4jLogger.class.getSuperclass();
+      Field logger = log4jLoggerSuperCls.getDeclaredField("logger");
+      if (!Modifier.isPublic(logger.getModifiers())) {
+        logger.setAccessible(true);
+      }
+      fieldLogger = logger;
+      Class<?> asyncLoggerSuperCls = AsyncLogger.class.getSuperclass();
+      Field loggerDisruptor = asyncLoggerSuperCls.getDeclaredField("loggerDisruptor");
+      if (!Modifier.isPublic(loggerDisruptor.getModifiers())) {
+        loggerDisruptor.setAccessible(true);
+      }
+      fieldDisruptor = loggerDisruptor;
     } catch (Throwable e) {
       LOGGER.error("failed to getDeclaredField to hack", e);
     }

--- a/server/remoting/bolt/src/main/java/com/alipay/sofa/registry/remoting/bolt/exchange/BoltExchange.java
+++ b/server/remoting/bolt/src/main/java/com/alipay/sofa/registry/remoting/bolt/exchange/BoltExchange.java
@@ -28,7 +28,7 @@ import com.alipay.sofa.registry.util.OsUtils;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author shangyu.wh

--- a/server/server/data/pom.xml
+++ b/server/server/data/pom.xml
@@ -72,8 +72,8 @@
             <artifactId>hibernate-validator</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-collections</groupId>

--- a/server/server/data/src/main/java/com/alipay/sofa/registry/server/data/bootstrap/DataServerConfig.java
+++ b/server/server/data/src/main/java/com/alipay/sofa/registry/server/data/bootstrap/DataServerConfig.java
@@ -21,8 +21,8 @@ import com.alipay.sofa.registry.server.shared.config.ServerShareConfig;
 import com.alipay.sofa.registry.server.shared.env.ServerEnv;
 import com.alipay.sofa.registry.util.OsUtils;
 import java.util.Collection;
-import org.apache.commons.lang.builder.ToStringBuilder;
-import org.apache.commons.lang.builder.ToStringStyle;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**

--- a/server/server/data/src/main/java/com/alipay/sofa/registry/server/data/cache/DatumStorageDelegate.java
+++ b/server/server/data/src/main/java/com/alipay/sofa/registry/server/data/cache/DatumStorageDelegate.java
@@ -30,7 +30,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import java.util.*;
 import java.util.function.BiConsumer;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * cache of datum, providing query function to the upper module

--- a/server/server/data/src/main/java/com/alipay/sofa/registry/server/data/cache/PublisherGroups.java
+++ b/server/server/data/src/main/java/com/alipay/sofa/registry/server/data/cache/PublisherGroups.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.glassfish.jersey.internal.guava.Sets;
 import org.springframework.util.CollectionUtils;
 

--- a/server/server/data/src/main/java/com/alipay/sofa/registry/server/data/providedata/CompressDatumService.java
+++ b/server/server/data/src/main/java/com/alipay/sofa/registry/server/data/providedata/CompressDatumService.java
@@ -29,7 +29,7 @@ import com.alipay.sofa.registry.server.data.bootstrap.DataServerConfig;
 import com.alipay.sofa.registry.server.shared.providedata.AbstractFetchSystemPropertyService;
 import com.alipay.sofa.registry.server.shared.providedata.SystemDataStorage;
 import com.alipay.sofa.registry.util.JsonUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class CompressDatumService

--- a/server/server/data/src/main/java/com/alipay/sofa/registry/server/data/resource/DataDigestResource.java
+++ b/server/server/data/src/main/java/com/alipay/sofa/registry/server/data/resource/DataDigestResource.java
@@ -37,7 +37,7 @@ import java.util.*;
 import java.util.Map.Entry;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.CollectionUtils;
 

--- a/server/server/data/src/main/java/com/alipay/sofa/registry/server/data/resource/DatumApiResource.java
+++ b/server/server/data/src/main/java/com/alipay/sofa/registry/server/data/resource/DatumApiResource.java
@@ -41,8 +41,8 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**

--- a/server/server/data/src/main/java/com/alipay/sofa/registry/server/data/slot/SlotAccessorDelegate.java
+++ b/server/server/data/src/main/java/com/alipay/sofa/registry/server/data/slot/SlotAccessorDelegate.java
@@ -25,7 +25,7 @@ import com.alipay.sofa.registry.common.model.slot.func.SlotFunctionRegistry;
 import com.alipay.sofa.registry.server.data.bootstrap.DataServerConfig;
 import com.alipay.sofa.registry.server.data.multi.cluster.slot.MultiClusterSlotManager;
 import java.util.List;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**

--- a/server/server/data/src/main/java/com/alipay/sofa/registry/server/data/slot/SlotManagerImpl.java
+++ b/server/server/data/src/main/java/com/alipay/sofa/registry/server/data/slot/SlotManagerImpl.java
@@ -54,7 +54,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import javax.annotation.PostConstruct;
 import javax.annotation.Resource;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.CollectionUtils;
 

--- a/server/server/data/src/main/java/com/alipay/sofa/registry/server/data/slot/SyncLeaderTask.java
+++ b/server/server/data/src/main/java/com/alipay/sofa/registry/server/data/slot/SyncLeaderTask.java
@@ -21,7 +21,7 @@ import com.alipay.sofa.registry.log.Logger;
 import com.alipay.sofa.registry.server.shared.remoting.ClientSideExchanger;
 import com.alipay.sofa.registry.task.TaskErrorSilenceException;
 import com.alipay.sofa.registry.util.StringFormatter;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author xiaojian.xj

--- a/server/server/data/src/main/java/com/alipay/sofa/registry/server/data/timer/CacheDigestTask.java
+++ b/server/server/data/src/main/java/com/alipay/sofa/registry/server/data/timer/CacheDigestTask.java
@@ -33,7 +33,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.PostConstruct;
-import org.apache.commons.lang.time.DateUtils;
+import org.apache.commons.lang3.time.DateUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.CollectionUtils;
 

--- a/server/server/integration/src/main/java/com/alipay/sofa/registry/server/integration/RegistryApplication.java
+++ b/server/server/integration/src/main/java/com/alipay/sofa/registry/server/integration/RegistryApplication.java
@@ -41,8 +41,7 @@ import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Collections;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
-import org.apache.logging.log4j.util.Strings;
+import org.apache.commons.lang3.StringUtils;
 import org.h2.tools.Server;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -284,7 +283,7 @@ public class RegistryApplication {
     PreparedStatement stmt = null;
     try {
       conn.setAutoCommit(false);
-      if (!Strings.isEmpty(prepareSql)) {
+      if (!StringUtils.isEmpty(prepareSql)) {
         for (String sql : prepareSql.split(";")) {
           LOGGER.debug("[setup][data]{}", sql.trim());
           stmt = conn.prepareStatement(sql);

--- a/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/bootstrap/MetaServerBootstrap.java
+++ b/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/bootstrap/MetaServerBootstrap.java
@@ -50,7 +50,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Resource;
 import javax.ws.rs.Path;
 import javax.ws.rs.ext.Provider;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;

--- a/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/bootstrap/config/MetaServerConfigBean.java
+++ b/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/bootstrap/config/MetaServerConfigBean.java
@@ -22,8 +22,8 @@ import com.alipay.sofa.registry.util.OsUtils;
 import com.alipay.sofa.registry.util.SystemUtils;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import org.apache.commons.lang.builder.ToStringBuilder;
-import org.apache.commons.lang.builder.ToStringStyle;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**

--- a/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/lease/filter/DefaultForbiddenServerManager.java
+++ b/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/lease/filter/DefaultForbiddenServerManager.java
@@ -33,7 +33,7 @@ import com.alipay.sofa.registry.server.meta.provide.data.NodeOperatingService;
 import com.alipay.sofa.registry.server.meta.provide.data.ProvideDataService;
 import com.alipay.sofa.registry.util.JsonUtils;
 import java.util.Set;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**

--- a/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/monitor/impl/DefaultSlotStats.java
+++ b/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/monitor/impl/DefaultSlotStats.java
@@ -24,7 +24,7 @@ import com.alipay.sofa.registry.server.meta.monitor.SlotStats;
 import com.google.common.collect.Maps;
 import java.util.Map;
 import java.util.Objects;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author chen.zhu

--- a/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/monitor/impl/DefaultSlotTableStats.java
+++ b/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/monitor/impl/DefaultSlotTableStats.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author chen.zhu

--- a/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/remoting/meta/LocalMetaExchanger.java
+++ b/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/remoting/meta/LocalMetaExchanger.java
@@ -30,7 +30,7 @@ import com.alipay.sofa.registry.store.api.elector.AbstractLeaderElector;
 import com.alipay.sofa.registry.util.StringFormatter;
 import java.util.Collection;
 import java.util.Collections;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**

--- a/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/remoting/meta/MetaNodeExchange.java
+++ b/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/remoting/meta/MetaNodeExchange.java
@@ -32,7 +32,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**

--- a/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/CircuitBreakerResources.java
+++ b/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/CircuitBreakerResources.java
@@ -39,7 +39,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author xiaojian.xj

--- a/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/ClientManagerResource.java
+++ b/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/ClientManagerResource.java
@@ -38,7 +38,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.util.CollectionUtils;
 
 /**

--- a/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/CompressResource.java
+++ b/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/CompressResource.java
@@ -35,7 +35,7 @@ import com.alipay.sofa.registry.util.JsonUtils;
 import com.google.common.collect.Sets;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @Path("compress")

--- a/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/HealthResource.java
+++ b/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/HealthResource.java
@@ -32,7 +32,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**

--- a/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/MetaLeaderResource.java
+++ b/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/MetaLeaderResource.java
@@ -30,7 +30,7 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**

--- a/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/MultiClusterSyncResource.java
+++ b/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/MultiClusterSyncResource.java
@@ -34,8 +34,8 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.math.NumberUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**

--- a/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/MultiDatumResource.java
+++ b/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/MultiDatumResource.java
@@ -30,7 +30,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**

--- a/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/RecoverConfigResource.java
+++ b/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/RecoverConfigResource.java
@@ -25,7 +25,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**

--- a/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/RegistryCoreOpsResource.java
+++ b/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/RegistryCoreOpsResource.java
@@ -32,7 +32,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import sun.net.util.IPAddressUtil;
 

--- a/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/RegistryCoreOpsV2Resource.java
+++ b/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/RegistryCoreOpsV2Resource.java
@@ -32,7 +32,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import sun.net.util.IPAddressUtil;
 

--- a/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/ShutdownSwitchResource.java
+++ b/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/ShutdownSwitchResource.java
@@ -42,7 +42,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @Path("shutdown")

--- a/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/filter/AuthRestFilter.java
+++ b/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/filter/AuthRestFilter.java
@@ -34,7 +34,7 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.CollectionUtils;
 

--- a/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/filter/LeaderAwareFilter.java
+++ b/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/resource/filter/LeaderAwareFilter.java
@@ -29,7 +29,7 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**

--- a/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/slot/balance/DefaultSlotBalancer.java
+++ b/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/slot/balance/DefaultSlotBalancer.java
@@ -34,7 +34,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author chen.zhu

--- a/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/slot/util/builder/SlotBuilder.java
+++ b/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/slot/util/builder/SlotBuilder.java
@@ -23,7 +23,7 @@ import com.google.common.collect.Sets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author chen.zhu

--- a/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/slot/util/builder/SlotTableBuilder.java
+++ b/server/server/meta/src/main/java/com/alipay/sofa/registry/server/meta/slot/util/builder/SlotTableBuilder.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author chen.zhu

--- a/server/server/meta/src/test/java/com/alipay/sofa/registry/server/meta/AbstractH2DbTestBase.java
+++ b/server/server/meta/src/test/java/com/alipay/sofa/registry/server/meta/AbstractH2DbTestBase.java
@@ -25,8 +25,7 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
-import org.apache.logging.log4j.util.Strings;
+import org.apache.commons.lang3.StringUtils;
 import org.h2.tools.Server;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
@@ -164,7 +163,7 @@ public class AbstractH2DbTestBase extends AbstractTestBase implements Applicatio
     PreparedStatement stmt = null;
     try {
       conn.setAutoCommit(false);
-      if (!Strings.isEmpty(prepareSql)) {
+      if (!StringUtils.isEmpty(prepareSql)) {
         for (String sql : prepareSql.split(";")) {
           stmt = conn.prepareStatement(sql);
           stmt.executeUpdate();

--- a/server/server/meta/src/test/java/com/alipay/sofa/registry/server/meta/resource/MultiClusterSyncResourceTest.java
+++ b/server/server/meta/src/test/java/com/alipay/sofa/registry/server/meta/resource/MultiClusterSyncResourceTest.java
@@ -23,7 +23,7 @@ import com.alipay.sofa.registry.test.TestUtils.MockMultiClusterSyncRepository;
 import java.util.Collections;
 import java.util.Locale;
 import java.util.Set;
-import org.apache.logging.log4j.util.Strings;
+import org.apache.commons.lang3.StringUtils;
 import org.glassfish.jersey.internal.guava.Sets;
 import org.junit.Assert;
 import org.junit.Test;
@@ -347,7 +347,7 @@ public class MultiClusterSyncResourceTest {
 
     // update fail
     Set<String> idSet1 = Collections.singleton("test-id1");
-    String ids1 = Strings.join(idSet1, ',');
+    String ids1 = StringUtils.join(idSet1, ',');
 
     response =
         multiClusterSyncResource.addSyncDataInfoIds(

--- a/server/server/session/pom.xml
+++ b/server/server/session/pom.xml
@@ -98,8 +98,8 @@
         </dependency>
 
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
             <groupId>com.github.rholder</groupId>

--- a/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/bootstrap/SessionServerConfigBean.java
+++ b/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/bootstrap/SessionServerConfigBean.java
@@ -24,9 +24,9 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.builder.ToStringBuilder;
-import org.apache.commons.lang.builder.ToStringStyle;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**

--- a/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/connections/ConnectionsService.java
+++ b/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/connections/ConnectionsService.java
@@ -33,7 +33,7 @@ import com.google.common.collect.Sets;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class ConnectionsService {

--- a/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/converter/ReceivedDataConverter.java
+++ b/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/converter/ReceivedDataConverter.java
@@ -43,7 +43,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.Predicate;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.util.CollectionUtils;
 
 /**

--- a/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/filter/blacklist/DefaultIPMatchStrategy.java
+++ b/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/filter/blacklist/DefaultIPMatchStrategy.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
 import javax.annotation.Resource;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author shangyu.wh

--- a/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/mapper/ConnectionMapper.java
+++ b/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/mapper/ConnectionMapper.java
@@ -19,7 +19,7 @@ package com.alipay.sofa.registry.server.session.mapper;
 import com.google.common.collect.Maps;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author ruoshan

--- a/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/node/service/DataNodeServiceImpl.java
+++ b/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/node/service/DataNodeServiceImpl.java
@@ -57,7 +57,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.PostConstruct;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**

--- a/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/providedata/AppRevisionWriteSwitchService.java
+++ b/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/providedata/AppRevisionWriteSwitchService.java
@@ -25,7 +25,7 @@ import com.alipay.sofa.registry.server.session.bootstrap.SessionServerConfig;
 import com.alipay.sofa.registry.server.shared.providedata.AbstractFetchSystemPropertyService;
 import com.alipay.sofa.registry.server.shared.providedata.SystemDataStorage;
 import com.alipay.sofa.registry.util.JsonUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /** Author dzdx @Date 2022/8/8 15:11 @Version 1.0 */

--- a/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/providedata/CompressPushService.java
+++ b/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/providedata/CompressPushService.java
@@ -31,7 +31,7 @@ import com.alipay.sofa.registry.server.shared.providedata.SystemDataStorage;
 import com.alipay.sofa.registry.util.JsonUtils;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class CompressPushService

--- a/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/providedata/FetchGrayPushSwitchService.java
+++ b/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/providedata/FetchGrayPushSwitchService.java
@@ -34,7 +34,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class FetchGrayPushSwitchService

--- a/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/providedata/FetchPushEfficiencyConfigService.java
+++ b/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/providedata/FetchPushEfficiencyConfigService.java
@@ -29,7 +29,7 @@ import com.alipay.sofa.registry.server.shared.providedata.AbstractFetchSystemPro
 import com.alipay.sofa.registry.server.shared.providedata.SystemDataStorage;
 import com.alipay.sofa.registry.util.JsonUtils;
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**

--- a/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/push/PushEfficiencyImproveConfig.java
+++ b/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/push/PushEfficiencyImproveConfig.java
@@ -21,7 +21,7 @@ import com.alipay.sofa.registry.server.session.bootstrap.SessionServerConfig;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author jiangcun.hlc@antfin.com

--- a/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/registry/RegistryScanCallable.java
+++ b/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/registry/RegistryScanCallable.java
@@ -34,7 +34,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.CollectionUtils;
 

--- a/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/remoting/handler/MetadataRegisterPbHandler.java
+++ b/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/remoting/handler/MetadataRegisterPbHandler.java
@@ -23,7 +23,7 @@ import com.alipay.sofa.registry.remoting.Channel;
 import com.alipay.sofa.registry.server.session.converter.pb.AppRevisionConvertor;
 import com.alipay.sofa.registry.server.session.converter.pb.RegisterResponseConvertor;
 import com.alipay.sofa.registry.server.shared.remoting.RemotingHelper;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author xiaojian.xj

--- a/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/remoting/handler/ServiceAppMappingPbHandler.java
+++ b/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/remoting/handler/ServiceAppMappingPbHandler.java
@@ -21,7 +21,7 @@ import com.alipay.sofa.registry.remoting.Channel;
 import com.alipay.sofa.registry.server.shared.remoting.RemotingHelper;
 import com.alipay.sofa.registry.util.ParaCheckUtil;
 import java.util.List;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author xiaojian.xj

--- a/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/resource/ClientManagerResource.java
+++ b/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/resource/ClientManagerResource.java
@@ -49,7 +49,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**

--- a/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/resource/PersistenceClientManagerResource.java
+++ b/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/resource/PersistenceClientManagerResource.java
@@ -39,7 +39,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.CollectionUtils;
 

--- a/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/resource/Sdks.java
+++ b/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/resource/Sdks.java
@@ -36,7 +36,7 @@ import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.util.CollectionUtils;
 
 public final class Sdks {

--- a/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/resource/SessionOpenResource.java
+++ b/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/resource/SessionOpenResource.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**

--- a/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/scheduler/timertask/SessionCacheDigestTask.java
+++ b/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/scheduler/timertask/SessionCacheDigestTask.java
@@ -33,7 +33,7 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.annotation.PostConstruct;
-import org.apache.commons.lang.time.DateUtils;
+import org.apache.commons.lang3.time.DateUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**

--- a/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/slot/SlotTableCacheImpl.java
+++ b/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/slot/SlotTableCacheImpl.java
@@ -40,7 +40,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 import javax.annotation.PostConstruct;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.CollectionUtils;
 

--- a/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/store/SessionInterests.java
+++ b/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/store/SessionInterests.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.util.CollectionUtils;
 
 /**

--- a/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/strategy/impl/DefaultPublisherHandlerStrategy.java
+++ b/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/strategy/impl/DefaultPublisherHandlerStrategy.java
@@ -32,7 +32,7 @@ import com.alipay.sofa.registry.server.session.registry.Registry;
 import com.alipay.sofa.registry.server.session.strategy.PublisherHandlerStrategy;
 import com.alipay.sofa.registry.server.shared.remoting.RemotingHelper;
 import com.alipay.sofa.registry.server.shared.util.DatumUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.core.async.Hack;
 import org.springframework.beans.factory.annotation.Autowired;
 

--- a/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/strategy/impl/DefaultSubscriberHandlerStrategy.java
+++ b/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/strategy/impl/DefaultSubscriberHandlerStrategy.java
@@ -32,7 +32,7 @@ import com.alipay.sofa.registry.server.session.converter.SubscriberConverter;
 import com.alipay.sofa.registry.server.session.registry.Registry;
 import com.alipay.sofa.registry.server.session.strategy.SubscriberHandlerStrategy;
 import com.alipay.sofa.registry.server.shared.remoting.RemotingHelper;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.core.async.Hack;
 import org.springframework.beans.factory.annotation.Autowired;
 

--- a/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/strategy/impl/DefaultWatcherHandlerStrategy.java
+++ b/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/strategy/impl/DefaultWatcherHandlerStrategy.java
@@ -30,7 +30,7 @@ import com.alipay.sofa.registry.remoting.bolt.BoltUtil;
 import com.alipay.sofa.registry.server.session.converter.SubscriberConverter;
 import com.alipay.sofa.registry.server.session.registry.Registry;
 import com.alipay.sofa.registry.server.session.strategy.WatcherHandlerStrategy;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**

--- a/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/wrapper/BlacklistWrapperInterceptor.java
+++ b/server/server/session/src/main/java/com/alipay/sofa/registry/server/session/wrapper/BlacklistWrapperInterceptor.java
@@ -28,7 +28,7 @@ import com.alipay.sofa.registry.server.session.loggers.Loggers;
 import com.alipay.sofa.registry.server.session.push.FirePushService;
 import com.alipay.sofa.registry.server.session.registry.SessionRegistry;
 import com.alipay.sofa.registry.server.shared.remoting.RemotingHelper;
-import org.apache.logging.log4j.util.Strings;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -52,7 +52,7 @@ public class BlacklistWrapperInterceptor
 
     RegisterInvokeData registerInvokeData = invocation.getParameterSupplier().get();
     BaseInfo storeData = (BaseInfo) registerInvokeData.getStoreData();
-    if (Strings.isNotBlank(storeData.attributeOf(ValueConstants.BLOCKED_REQUEST_KEY))
+    if (StringUtils.isNotBlank(storeData.attributeOf(ValueConstants.BLOCKED_REQUEST_KEY))
         || processFilter.match(storeData)) {
       if (DataType.PUBLISHER == storeData.getDataType()) {
         // match blacklist stop pub.

--- a/server/server/session/src/test/java/com/alipay/sofa/registry/server/session/converter/ReceivedDataConverterTest.java
+++ b/server/server/session/src/test/java/com/alipay/sofa/registry/server/session/converter/ReceivedDataConverterTest.java
@@ -38,7 +38,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.Predicate;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.assertj.core.util.Sets;
 import org.junit.Assert;
 import org.junit.Test;

--- a/server/server/shared/pom.xml
+++ b/server/server/shared/pom.xml
@@ -78,8 +78,8 @@
             <artifactId>protobuf-java</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
             <groupId>com.alipay.sofa</groupId>

--- a/server/server/shared/src/main/java/com/alipay/sofa/registry/server/shared/config/CommonConfig.java
+++ b/server/server/shared/src/main/java/com/alipay/sofa/registry/server/shared/config/CommonConfig.java
@@ -19,8 +19,8 @@ package com.alipay.sofa.registry.server.shared.config;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
-import org.apache.commons.lang.builder.ToStringBuilder;
-import org.apache.commons.lang.builder.ToStringStyle;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.springframework.beans.factory.annotation.Value;
 
 /**

--- a/server/server/shared/src/main/java/com/alipay/sofa/registry/server/shared/env/ServerEnv.java
+++ b/server/server/shared/src/main/java/com/alipay/sofa/registry/server/shared/env/ServerEnv.java
@@ -24,7 +24,7 @@ import com.alipay.sofa.registry.util.ParaCheckUtil;
 import java.io.InputStream;
 import java.util.*;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author yuzhi.lyz

--- a/server/server/shared/src/main/java/com/alipay/sofa/registry/server/shared/meta/AbstractMetaLeaderExchanger.java
+++ b/server/server/shared/src/main/java/com/alipay/sofa/registry/server/shared/meta/AbstractMetaLeaderExchanger.java
@@ -45,7 +45,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.PostConstruct;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**

--- a/server/server/shared/src/main/java/com/alipay/sofa/registry/server/shared/meta/AbstractMetaServerService.java
+++ b/server/server/shared/src/main/java/com/alipay/sofa/registry/server/shared/meta/AbstractMetaServerService.java
@@ -45,7 +45,7 @@ import com.google.common.collect.Sets;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.CollectionUtils;
 

--- a/server/server/shared/src/main/java/com/alipay/sofa/registry/server/shared/providedata/AbstractFetchPersistenceSystemProperty.java
+++ b/server/server/shared/src/main/java/com/alipay/sofa/registry/server/shared/providedata/AbstractFetchPersistenceSystemProperty.java
@@ -24,7 +24,7 @@ import com.alipay.sofa.registry.util.StringFormatter;
 import com.alipay.sofa.registry.util.WakeUpLoopRunnable;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author xiaojian.xj

--- a/server/server/shared/src/main/java/com/alipay/sofa/registry/server/shared/providedata/AbstractFetchSystemPropertyService.java
+++ b/server/server/shared/src/main/java/com/alipay/sofa/registry/server/shared/providedata/AbstractFetchSystemPropertyService.java
@@ -28,7 +28,7 @@ import com.alipay.sofa.registry.util.WakeUpLoopRunnable;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.Assert;
 

--- a/server/server/shared/src/main/java/com/alipay/sofa/registry/server/shared/resource/AuthChecker.java
+++ b/server/server/shared/src/main/java/com/alipay/sofa/registry/server/shared/resource/AuthChecker.java
@@ -16,7 +16,7 @@
  */
 package com.alipay.sofa.registry.server.shared.resource;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author xiaojian.xj

--- a/server/server/shared/src/main/java/com/alipay/sofa/registry/server/shared/slot/SlotTableUtils.java
+++ b/server/server/shared/src/main/java/com/alipay/sofa/registry/server/shared/slot/SlotTableUtils.java
@@ -22,7 +22,7 @@ import com.alipay.sofa.registry.log.Logger;
 import com.alipay.sofa.registry.log.LoggerFactory;
 import com.google.common.collect.Maps;
 import java.util.Map;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author chen.zhu

--- a/server/server/shared/src/main/java/com/alipay/sofa/registry/server/shared/util/PersistenceDataParser.java
+++ b/server/server/shared/src/main/java/com/alipay/sofa/registry/server/shared/util/PersistenceDataParser.java
@@ -19,7 +19,7 @@ package com.alipay.sofa.registry.server.shared.util;
 import com.alipay.sofa.registry.common.model.console.PersistenceData;
 import com.alipay.sofa.registry.store.api.DBResponse;
 import com.alipay.sofa.registry.store.api.OperationStatus;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author xiaojian.xj

--- a/server/store/api/src/main/java/com/alipay/sofa/registry/store/api/config/DefaultCommonConfigBean.java
+++ b/server/store/api/src/main/java/com/alipay/sofa/registry/store/api/config/DefaultCommonConfigBean.java
@@ -22,7 +22,7 @@ import com.alipay.sofa.registry.store.api.meta.RecoverConfigRepository;
 import com.alipay.sofa.registry.store.api.spring.SpringContext;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Set;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.util.CollectionUtils;

--- a/server/store/api/src/main/java/com/alipay/sofa/registry/store/api/elector/AbstractLeaderElector.java
+++ b/server/store/api/src/main/java/com/alipay/sofa/registry/store/api/elector/AbstractLeaderElector.java
@@ -26,7 +26,7 @@ import com.google.common.collect.Lists;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.PostConstruct;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author chen.zhu

--- a/server/store/jdbc/src/main/java/com/alipay/sofa/registry/jdbc/convertor/AppRevisionDomainConvertor.java
+++ b/server/store/jdbc/src/main/java/com/alipay/sofa/registry/jdbc/convertor/AppRevisionDomainConvertor.java
@@ -23,7 +23,7 @@ import com.alipay.sofa.registry.util.JsonUtils;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.util.CollectionUtils;
 
 /**

--- a/server/store/jdbc/src/main/java/com/alipay/sofa/registry/jdbc/repository/impl/RecoverConfigJdbcRepository.java
+++ b/server/store/jdbc/src/main/java/com/alipay/sofa/registry/jdbc/repository/impl/RecoverConfigJdbcRepository.java
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;

--- a/server/store/jdbc/src/test/java/com/alipay/sofa/registry/jdbc/AbstractH2DbTestBase.java
+++ b/server/store/jdbc/src/test/java/com/alipay/sofa/registry/jdbc/AbstractH2DbTestBase.java
@@ -34,8 +34,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.sql.DataSource;
-import org.apache.commons.lang.StringUtils;
-import org.apache.logging.log4j.util.Strings;
+import org.apache.commons.lang3.StringUtils;
 import org.h2.tools.Console;
 import org.h2.tools.Server;
 import org.junit.Before;
@@ -114,7 +113,7 @@ public class AbstractH2DbTestBase extends AbstractTest implements ApplicationCon
     try {
       conn = dataSource.getConnection();
       conn.setAutoCommit(false);
-      if (!Strings.isEmpty(prepareSql)) {
+      if (!StringUtils.isEmpty(prepareSql)) {
         for (String sql : prepareSql.split(";")) {
           logger.debug("[setup][data]{}", sql.trim());
           stmt = conn.prepareStatement(sql);

--- a/server/store/jdbc/src/test/java/com/alipay/sofa/registry/jdbc/elector/MetaJdbcLeaderElectorTest.java
+++ b/server/store/jdbc/src/test/java/com/alipay/sofa/registry/jdbc/elector/MetaJdbcLeaderElectorTest.java
@@ -29,9 +29,9 @@ import com.alipay.sofa.registry.util.StringFormatter;
 import com.google.common.collect.Lists;
 import java.util.Date;
 import java.util.List;
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import org.apache.commons.lang.math.RandomUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -136,7 +136,8 @@ public class MetaJdbcLeaderElectorTest extends AbstractH2DbTestBase {
 
     @Override
     public void waitingUnthrowable() {
-      int sleep = (int) (RandomUtils.nextFloat() * 150 + 150);
+      Random random = new Random();
+      int sleep = (int) (random.nextFloat() * 150 + 150);
       ConcurrentUtils.sleepUninterruptibly(sleep, TimeUnit.MILLISECONDS);
     }
   }

--- a/server/store/jraft/pom.xml
+++ b/server/store/jraft/pom.xml
@@ -43,8 +43,8 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/test/src/test/java/com/alipay/sofa/registry/test/BaseIntegrationTest.java
+++ b/test/src/test/java/com/alipay/sofa/registry/test/BaseIntegrationTest.java
@@ -69,7 +69,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.h2.tools.Server;
 import org.junit.Assert;
 import org.junit.Before;


### PR DESCRIPTION
### Motivation:

The usage of Log4j2 Strings Util class in the code makes users force dependency on log4j2. We can use commons-lang instead or maintain self Utils of String in the project.

### Modification:
Bump commons-lang to commons-lang3. And used the commons-lang3 to instead `Strings` usage of Log4j2 in the code.

### Result:

Fixes #345 . 
