### PR TITLE
fix issue: Specified key was too long; max key length is 3072 bytes

### DIFF
--- a/create_table.sql
+++ b/create_table.sql
@@ -89,8 +89,8 @@ CREATE TABLE IF NOT EXISTS `recover_config`
 CREATE TABLE IF NOT EXISTS `multi_cluster_sync_info`
 (
     `id`                   bigint(20)    NOT NULL AUTO_INCREMENT COMMENT '主键',
-    `data_center`          varchar(512)  NOT NULL COMMENT '集群名称',
-    `remote_data_center`   varchar(512)  NOT NULL COMMENT '同步的集群名称',
+    `data_center`          varchar(255)  NOT NULL COMMENT '集群名称',
+    `remote_data_center`   varchar(255)  NOT NULL COMMENT '同步的集群名称',
     `remote_meta_address`  varchar(1024) NOT NULL COMMENT '同步的集群地址',
     `enable_sync_datum`    varchar(16)   NOT NULL COMMENT 'datum同步的开关是否开启',
     `enable_push`          varchar(16)   NOT NULL COMMENT '同步的数据是否允许推送',


### PR DESCRIPTION
### Motivation:

Fix script issue when run under mysql 


### Reference:

[SQL issue-[Script issue]: Specified key was too long; max key length is 3072 bytes](https://github.com/sofastack/sofa-registry/issues/356)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Reduced the maximum length of `data_center` and `remote_data_center` fields from 512 to 255 characters in the `multi_cluster_sync_info` table, optimizing storage and improving performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->