### PR TITLE
docs: Add English README documentation（#366）

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,53 +6,55 @@
 [![codecov](https://codecov.io/gh/sofastack/sofa-registry/branch/master/graph/badge.svg?token=K6x7h4Uxkn)](https://codecov.io/gh/sofastack/sofa-registry)
 ![maven](https://img.shields.io/github/release/sofastack/sofa-registry.svg)
 
-SOFARegistry 是蚂蚁金服开源的一个生产级、高时效、高可用的服务注册中心。SOFARegistry 最早源自于淘宝的 ConfigServer，十年来，随着蚂蚁金服的业务发展，注册中心架构已经演进至第六代。目前 SOFARegistry 不仅全面服务于蚂蚁金服的自有业务，还随着蚂蚁金融科技服务众多合作伙伴，同时也兼容开源生态。SOFARegistry 采用 AP 架构，支持秒级时效性推送，同时采用分层架构支持无限水平扩展。
+[中文版本](./README_ZH.md)
 
-## 功能特性 
+SOFARegistry is a production-level, low-latency, high-availability service registry powered by Ant Financial.SOFARegistry originated from Taobao's ConfigServer. Over the past decade, as Ant Group's business has grown, its registry architecture has evolved to its sixth generation. Currently, SOFARegistry not only fully supports Ant Group's internal services, but also serves numerous partners through Ant Financial Technology while maintaining compatibility with the open-source ecosystem. Adopting an AP architecture, SOFARegistry enables millisecond-level real-time push notifications. Additionally, its layered architecture supports unlimited horizontal scalability.
 
-- 支持服务发布与服务订阅
-- 支持服务变更时的主动推送
-- 丰富的 REST 接口
-- 采用分层架构及数据分片，支持海量连接及海量数据
-- 支持多副本备份，保证数据高可用
-- 基于 [SOFABolt](https://github.com/alipay/sofa-bolt) 通信框架，服务上下线秒级通知
-- AP 架构，保证网络分区下的可用性
+## Functionality 
 
-
-## 需要
-
-编译需要 JDK 8 及以上、Maven 3.2.5 及以上。
-
-运行需要 JDK 6 及以上，服务端运行需要 JDK 8及以上。
-
-**推荐使用JDK 8，JDK 16尚未被测试，可能会有兼容性问题**
-
-## 文档
-
-- [快速开始](https://www.sofastack.tech/sofa-registry/docs/Server-QuickStart)
-- [开发手册](https://www.sofastack.tech/sofa-registry/docs/JAVA-SDK)
-- [运维手册](https://www.sofastack.tech/sofa-registry/docs/Deployment)
-- [发布历史](https://www.sofastack.tech/sofa-registry/docs/ReleaseNotes)
-- [发展路线](https://www.sofastack.tech/sofa-registry/docs/RoadMap)
-- 源码解析
-   - [发布订阅推送](https://www.sofastack.tech/projects/sofa-registry/code-analyze/code-analyze-publish-subscription-push/)
-   - [registry meta 选主](https://www.sofastack.tech/projects/sofa-registry/code-analyze/code-analyze-registry-meta/)
-   - [SlotTable](https://www.sofastack.tech/projects/sofa-registry/code-analyze/code-analyze-slottable/)
-   - [数据倒排索引](https://www.sofastack.tech/projects/sofa-registry/code-analyze/code-analyze-data-inverted-index/)
-   - [数据表监听](https://www.sofastack.tech/projects/sofa-registry/code-analyze/code-analyza-data-table-listening/)
-   - [无损运维](https://www.sofastack.tech/projects/sofa-registry/code-analyze/code-analyze-non-destructive-o-and-m/)
-   - [推送延迟 trace](https://www.sofastack.tech/projects/sofa-registry/code-analyze/code-analyze-push-delay-trace/)
-   - [推送开关](https://www.sofastack.tech/projects/sofa-registry/code-analyze/code-analyze-push-switch/)
-   - [通讯数据压缩](https://www.sofastack.tech/projects/sofa-registry/code-analyze/code-analyze-communication-data-compression/)
-## 贡献
-
-[如何参与 SOFARegistry 代码贡献](https://www.sofastack.tech/sofa-registry/docs/Contributing)
+- Supports service publishing and subscription
+- Provides active push notifications upon service changes
+- Offers comprehensive RESTful APIs
+- Employs layered architecture with data sharding to handle massive connections and large-scale datasets
+- Ensures high data availability through multi-replica backups
+- Enables millisecond-level notifications for service registration/deregistration via [SOFABolt](https://github.com/alipay/sofa-bolt) communication framework
+- AP architecture guarantees availability under network partitions
 
 
-## 致谢
+## Requirement
 
-SOFARegistry 最早源于阿里内部的 ConfigServer，感谢毕玄创造了 ConfigServer，使 SOFARegistry 的发展有了良好的基础。同时，部分代码参考了 Netflix 的 [Eureka](https://github.com/Netflix/eureka)，感谢 Netflix 开源了如此优秀框架。
+- Compilation requires JDK 8+ and Maven 3.2.5+
+- Runtime environment requires JDK 6+ (JDK 8+ for server-side deployment)
+- **Recommended: JDK 8 (JDK 16 has not been tested and may have compatibility issues)**
 
-## 开源许可
+## Docs
 
-SOFARegistry 基于 [Apache License 2.0](https://github.com/sofastack/sofa-registry/blob/master/LICENSE) 协议
+- [Quick Start](https://www.sofastack.tech/sofa-registry/docs/Server-QuickStart)
+- [Developer Guide](https://www.sofastack.tech/sofa-registry/docs/JAVA-SDK)
+- [Operations Manual](https://www.sofastack.tech/sofa-registry/docs/Deployment)
+- [Release Notes](https://www.sofastack.tech/sofa-registry/docs/ReleaseNotes)
+- [Roadmap](https://www.sofastack.tech/sofa-registry/docs/RoadMap)
+- Source Code Analysis
+  - [Publish-Subscribe Push](https://www.sofastack.tech/projects/sofa-registry/code-analyze/code-analyze-publish-subscription-push/)
+  - [Registry Meta Leader Election](https://www.sofastack.tech/projects/sofa-registry/code-analyze/code-analyze-registry-meta/)
+  - [SlotTable](https://www.sofastack.tech/projects/sofa-registry/code-analyze/code-analyze-slottable/)
+  - [Data Inverted Index](https://www.sofastack.tech/projects/sofa-registry/code-analyze/code-analyze-data-inverted-index/)
+  - [Data Table Monitoring](https://www.sofastack.tech/projects/sofa-registry/code-analyze/code-analyza-data-table-listening/)
+  - [Non-destructive Operations](https://www.sofastack.tech/projects/sofa-registry/code-analyze/code-analyze-non-destructive-o-and-m/)
+  - [Push Latency Tracing](https://www.sofastack.tech/projects/sofa-registry/code-analyze/code-analyze-push-delay-trace/)
+  - [Push Switch Mechanism](https://www.sofastack.tech/projects/sofa-registry/code-analyze/code-analyze-push-switch/)
+  - [Communication Data Compression](https://www.sofastack.tech/projects/sofa-registry/code-analyze/code-analyze-communication-data-compression/)
+
+## Contribute
+
+[How to Contribute to SOFARegistry](https://www.sofastack.tech/sofa-registry/docs/Contributing)
+
+
+## Acknowledgements
+
+SOFARegistry originally evolved from Alibaba's internal ConfigServer. We extend our gratitude to Bi Xuan(毕玄) for creating ConfigServer, which laid a solid foundation for SOFARegistry's development. The implementation references portions of code from Netflix's [Eureka](https://github.com/Netflix/eureka), and we are grateful to Netflix for open-sourcing this exceptional framework.
+
+
+## License
+
+SOFARegistry is licensed under the [Apache License 2.0](https://github.com/sofastack/sofa-registry/blob/master/LICENSE).

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@
 
 [中文版本](./README_ZH.md)
 
-SOFARegistry is a production-level, low-latency, high-availability service registry powered by Ant Financial.SOFARegistry originated from Taobao's ConfigServer. Over the past decade, as Ant Group's business has grown, its registry architecture has evolved to its sixth generation. Currently, SOFARegistry not only fully supports Ant Group's internal services, but also serves numerous partners through Ant Financial Technology while maintaining compatibility with the open-source ecosystem. Adopting an AP architecture, SOFARegistry enables millisecond-level real-time push notifications. Additionally, its layered architecture supports unlimited horizontal scalability.
+SOFARegistry is a production-level, low-latency, high-availability registry system for micro-services registration powered by Ant Financial.SOFARegistry originated from Taobao's ConfigServer. Over the past decade, as Ant Group's business has grown, its registry architecture has evolved to its sixth generation. Currently, SOFARegistry not only fully supports Ant Group's internal services, but also serves numerous partners through Ant Financial Technology while maintaining compatibility with the open-source ecosystem. Adopting an AP architecture, SOFARegistry enables millisecond-level real-time push notifications. Additionally, its layered architecture supports unlimited horizontal scalability.
 
 ## Functionality 
 
 - Supports service publishing and subscription
-- Provides active push notifications upon service changes
-- Offers comprehensive RESTful APIs
-- Employs layered architecture with data sharding to handle massive connections and large-scale datasets
-- Ensures high data availability through multi-replica backups
+- Provides real-time notifications upon service change
+- Offers enhanced service governance API endpoints
+- Employs multi-tier architecture for traffic and data wise to handle massive connections and large-scale datasets
+- Ensures high data availability through facility replication capabilities
 - Enables millisecond-level notifications for service registration/deregistration via [SOFABolt](https://github.com/alipay/sofa-bolt) communication framework
 - AP architecture guarantees availability under network partitions
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [中文版本](./README_ZH.md)
 
-SOFARegistry is a production-level, low-latency, high-availability registry system for micro-services registration powered by Ant Financial.SOFARegistry originated from Taobao's ConfigServer. Over the past decade, as Ant Group's business has grown, its registry architecture has evolved to its sixth generation. Currently, SOFARegistry not only fully supports Ant Group's internal services, but also serves numerous partners through Ant Financial Technology while maintaining compatibility with the open-source ecosystem. Adopting an AP architecture, SOFARegistry enables millisecond-level real-time push notifications. Additionally, its layered architecture supports unlimited horizontal scalability.
+SOFARegistry is a production-level, low-latency, high-availability registry system for micro-services registration powered by Ant Group. SOFARegistry originated from Taobao's ConfigServer. Over the past decade, as Ant Group's business has grown, its registry architecture has evolved to its sixth generation. Currently, SOFARegistry not only fully supports Ant Group's internal services, but also serves numerous partners through Ant Financial Technology while maintaining compatibility with the open-source ecosystem. Adopting an AP architecture, SOFARegistry enables millisecond-level real-time push notifications. Additionally, its layered architecture supports unlimited horizontal scalability.
 
 ## Functionality 
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -1,0 +1,58 @@
+# SOFARegistry
+
+[![unit test](https://github.com/sofastack/sofa-registry/actions/workflows/unit-test.yml/badge.svg)](https://github.com/sofastack/sofa-registry/actions/workflows/unit-test.yml)
+[![integration test](https://github.com/sofastack/sofa-registry/actions/workflows/integration-test.yml/badge.svg)](https://github.com/sofastack/sofa-registry/actions/workflows/integration-test.yml)
+![license](https://img.shields.io/badge/license-Apache--2.0-green.svg)
+[![codecov](https://codecov.io/gh/sofastack/sofa-registry/branch/master/graph/badge.svg?token=K6x7h4Uxkn)](https://codecov.io/gh/sofastack/sofa-registry)
+![maven](https://img.shields.io/github/release/sofastack/sofa-registry.svg)
+
+SOFARegistry 是蚂蚁金服开源的一个生产级、高时效、高可用的服务注册中心。SOFARegistry 最早源自于淘宝的 ConfigServer，十年来，随着蚂蚁金服的业务发展，注册中心架构已经演进至第六代。目前 SOFARegistry 不仅全面服务于蚂蚁金服的自有业务，还随着蚂蚁金融科技服务众多合作伙伴，同时也兼容开源生态。SOFARegistry 采用 AP 架构，支持秒级时效性推送，同时采用分层架构支持无限水平扩展。
+
+## 功能特性
+
+- 支持服务发布与服务订阅
+- 支持服务变更时的主动推送
+- 丰富的 REST 接口
+- 采用分层架构及数据分片，支持海量连接及海量数据
+- 支持多副本备份，保证数据高可用
+- 基于 [SOFABolt](https://github.com/alipay/sofa-bolt) 通信框架，服务上下线秒级通知
+- AP 架构，保证网络分区下的可用性
+
+
+## 需要
+
+编译需要 JDK 8 及以上、Maven 3.2.5 及以上。
+
+运行需要 JDK 6 及以上，服务端运行需要 JDK 8及以上。
+
+**推荐使用JDK 8，JDK 16尚未被测试，可能会有兼容性问题**
+
+## 文档
+
+- [快速开始](https://www.sofastack.tech/sofa-registry/docs/Server-QuickStart)
+- [开发手册](https://www.sofastack.tech/sofa-registry/docs/JAVA-SDK)
+- [运维手册](https://www.sofastack.tech/sofa-registry/docs/Deployment)
+- [发布历史](https://www.sofastack.tech/sofa-registry/docs/ReleaseNotes)
+- [发展路线](https://www.sofastack.tech/sofa-registry/docs/RoadMap)
+- 源码解析
+    - [发布订阅推送](https://www.sofastack.tech/projects/sofa-registry/code-analyze/code-analyze-publish-subscription-push/)
+    - [registry meta 选主](https://www.sofastack.tech/projects/sofa-registry/code-analyze/code-analyze-registry-meta/)
+    - [SlotTable](https://www.sofastack.tech/projects/sofa-registry/code-analyze/code-analyze-slottable/)
+    - [数据倒排索引](https://www.sofastack.tech/projects/sofa-registry/code-analyze/code-analyze-data-inverted-index/)
+    - [数据表监听](https://www.sofastack.tech/projects/sofa-registry/code-analyze/code-analyza-data-table-listening/)
+    - [无损运维](https://www.sofastack.tech/projects/sofa-registry/code-analyze/code-analyze-non-destructive-o-and-m/)
+    - [推送延迟 trace](https://www.sofastack.tech/projects/sofa-registry/code-analyze/code-analyze-push-delay-trace/)
+    - [推送开关](https://www.sofastack.tech/projects/sofa-registry/code-analyze/code-analyze-push-switch/)
+    - [通讯数据压缩](https://www.sofastack.tech/projects/sofa-registry/code-analyze/code-analyze-communication-data-compression/)
+## 贡献
+
+[如何参与 SOFARegistry 代码贡献](https://www.sofastack.tech/sofa-registry/docs/Contributing)
+
+
+## 致谢
+
+SOFARegistry 最早源于阿里内部的 ConfigServer，感谢毕玄创造了 ConfigServer，使 SOFARegistry 的发展有了良好的基础。同时，部分代码参考了 Netflix 的 [Eureka](https://github.com/Netflix/eureka)，感谢 Netflix 开源了如此优秀框架。
+
+## 开源许可
+
+SOFARegistry 基于 [Apache License 2.0](https://github.com/sofastack/sofa-registry/blob/master/LICENSE) 协议


### PR DESCRIPTION


Closes https://github.com/sofastack/sofa-registry/issues/366

### Motivation:

Document translation

### Modification:

- Create README_ZH.md with content synced to English version
- Add Chinese documentation to project root directory
- Improve documentation structure for Chinese readers

### Result:

Fixes #<366>. 

If there is no issue then describe the changes introduced by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Translated and reorganized project documentation to enhance clarity and accessibility for English-speaking users.
  - Updated and standardized section headers, expanding details on functionality, requirements, contribution guidelines, acknowledgements, and licensing.
  - Introduced a new native language version of the documentation to provide comprehensive insights into the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->