### PR TITLE
Add unit tests for ClientManagerResource zone methods and BlacklistWrapperInterceptor (#382)

### DIFF
--- a/server/server/session/src/test/java/com/alipay/sofa/registry/server/session/resource/ClientManagerResourceThrottlingTest.java
+++ b/server/server/session/src/test/java/com/alipay/sofa/registry/server/session/resource/ClientManagerResourceThrottlingTest.java
@@ -18,9 +18,11 @@ package com.alipay.sofa.registry.server.session.resource;
 
 import com.alipay.sofa.registry.common.model.CommonResponse;
 import com.alipay.sofa.registry.common.model.metaserver.limit.FlowOperationThrottlingStatus;
+import com.alipay.sofa.registry.server.session.bootstrap.SessionServerConfig;
 import com.alipay.sofa.registry.server.session.connections.ConnectionsService;
 import com.alipay.sofa.registry.server.session.limit.FlowOperationThrottlingObserver;
 import com.alipay.sofa.registry.server.session.registry.SessionRegistry;
+import com.alipay.sofa.registry.server.shared.meta.MetaServerService;
 import java.lang.reflect.Field;
 import java.util.Collections;
 import org.junit.Assert;
@@ -34,6 +36,8 @@ public class ClientManagerResourceThrottlingTest {
   private FlowOperationThrottlingObserver mockObserver;
   private ConnectionsService mockConnectionsService;
   private SessionRegistry mockSessionRegistry;
+  private SessionServerConfig mockSessionServerConfig;
+  private MetaServerService mockMetaServerService;
 
   @Before
   public void setUp() throws Exception {
@@ -41,16 +45,23 @@ public class ClientManagerResourceThrottlingTest {
     mockObserver = Mockito.mock(FlowOperationThrottlingObserver.class);
     mockConnectionsService = Mockito.mock(ConnectionsService.class);
     mockSessionRegistry = Mockito.mock(SessionRegistry.class);
+    mockSessionServerConfig = Mockito.mock(SessionServerConfig.class);
+    mockMetaServerService = Mockito.mock(MetaServerService.class);
 
     // Inject mocks using reflection
     setField(resource, "flowOperationThrottlingObserver", mockObserver);
     setField(resource, "connectionsService", mockConnectionsService);
     setField(resource, "sessionRegistry", mockSessionRegistry);
+    setField(resource, "sessionServerConfig", mockSessionServerConfig);
+    setField(resource, "metaServerService", mockMetaServerService);
 
     // Default mock behavior
     Mockito.when(mockConnectionsService.getIpConnects(Mockito.anySet()))
         .thenReturn(Collections.emptyList());
     Mockito.when(mockConnectionsService.closeIpConnects(Mockito.anyList()))
+        .thenReturn(Collections.emptyList());
+    Mockito.when(mockSessionServerConfig.getSessionServerRegion()).thenReturn("DEFAULT_ZONE");
+    Mockito.when(mockMetaServerService.getSessionServerList(Mockito.anyString()))
         .thenReturn(Collections.emptyList());
   }
 
@@ -208,5 +219,26 @@ public class ClientManagerResourceThrottlingTest {
     Assert.assertFalse(response.isSuccess());
     Assert.assertEquals("ips is empty", response.getMessage());
     Mockito.verify(mockObserver, Mockito.never()).shouldThrottle();
+  }
+
+  @Test
+  public void testClientOffInZoneNotThrottled() {
+    Mockito.when(mockObserver.shouldThrottle()).thenReturn(false);
+
+    CommonResponse response = resource.clientOffInZone("192.168.1.1");
+
+    Assert.assertTrue(response.isSuccess());
+    Mockito.verify(mockConnectionsService).getIpConnects(Mockito.anySet());
+    Mockito.verify(mockSessionRegistry).clientOff(Mockito.anyList());
+  }
+
+  @Test
+  public void testClientOnInZoneNotThrottled() {
+    Mockito.when(mockObserver.shouldThrottle()).thenReturn(false);
+
+    CommonResponse response = resource.clientOnInZone("192.168.1.1");
+
+    Assert.assertTrue(response.isSuccess());
+    Mockito.verify(mockConnectionsService).closeIpConnects(Mockito.anyList());
   }
 }

--- a/server/server/session/src/test/java/com/alipay/sofa/registry/server/session/wrapper/BlacklistWrapperInterceptorTest.java
+++ b/server/server/session/src/test/java/com/alipay/sofa/registry/server/session/wrapper/BlacklistWrapperInterceptorTest.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.registry.server.session.wrapper;
+
+import com.alipay.sofa.registry.common.model.constants.ValueConstants;
+import com.alipay.sofa.registry.common.model.store.Publisher;
+import com.alipay.sofa.registry.common.model.store.Subscriber;
+import com.alipay.sofa.registry.common.model.wrapper.WrapperInvocation;
+import com.alipay.sofa.registry.server.session.filter.ProcessFilter;
+import com.alipay.sofa.registry.server.session.push.FirePushService;
+import com.alipay.sofa.registry.server.session.registry.SessionRegistry;
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * @author huicha
+ * @date 2025/7/24
+ */
+public class BlacklistWrapperInterceptorTest {
+
+  @Test
+  public void testPublisherBlockedByAttribute() throws Exception {
+    BlacklistWrapperInterceptor interceptor = createInterceptor(false);
+
+    // Create a publisher with BLOCKED_REQUEST_KEY attribute set
+    Publisher publisher = new Publisher();
+    publisher.setDataInfoId("test-dataid#@#DEFAULT_INSTANCE_ID#@#test-group");
+    publisher.setDataId("test-dataid");
+    publisher.setGroup("test-group");
+    publisher.setInstanceId("DEFAULT_INSTANCE_ID");
+
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put(ValueConstants.BLOCKED_REQUEST_KEY, "true");
+    publisher.setAttributes(attributes);
+
+    RegisterInvokeData registerInvokeData = new RegisterInvokeData(publisher, null);
+    TouchChecker touchChecker = new TouchChecker(registerInvokeData);
+
+    WrapperInvocation<RegisterInvokeData, Boolean> invocation =
+        new WrapperInvocation<>(touchChecker, Collections.singletonList(interceptor));
+    Boolean result = invocation.proceed();
+
+    // Publisher with BLOCKED_REQUEST_KEY should be blocked (return true without calling proceed)
+    Assert.assertTrue(result);
+    Assert.assertFalse(touchChecker.hasBeenChecked());
+  }
+
+  @Test
+  public void testSubscriberBlockedByAttribute() throws Exception {
+    SessionRegistry mockRegistry = Mockito.mock(SessionRegistry.class);
+    Mockito.when(mockRegistry.isPushEmpty(Mockito.any(Subscriber.class))).thenReturn(true);
+    Mockito.when(mockRegistry.getDataCenterWhenPushEmpty()).thenReturn("DEFAULT_DC");
+
+    FirePushService mockFirePushService = Mockito.mock(FirePushService.class);
+
+    BlacklistWrapperInterceptor interceptor =
+        createInterceptor(false, mockRegistry, mockFirePushService);
+
+    Subscriber subscriber = new Subscriber();
+    subscriber.setDataInfoId("test-dataid#@#DEFAULT_INSTANCE_ID#@#test-group");
+    subscriber.setDataId("test-dataid");
+    subscriber.setGroup("test-group");
+    subscriber.setInstanceId("DEFAULT_INSTANCE_ID");
+
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put(ValueConstants.BLOCKED_REQUEST_KEY, "true");
+    subscriber.setAttributes(attributes);
+
+    RegisterInvokeData registerInvokeData = new RegisterInvokeData(subscriber, null);
+    TouchChecker touchChecker = new TouchChecker(registerInvokeData);
+
+    WrapperInvocation<RegisterInvokeData, Boolean> invocation =
+        new WrapperInvocation<>(touchChecker, Collections.singletonList(interceptor));
+    Boolean result = invocation.proceed();
+
+    Assert.assertTrue(result);
+    Assert.assertFalse(touchChecker.hasBeenChecked());
+    Mockito.verify(mockFirePushService).fireOnPushEmpty(Mockito.any(), Mockito.anyString());
+  }
+
+  @Test
+  public void testNotBlockedPassesThrough() throws Exception {
+    BlacklistWrapperInterceptor interceptor = createInterceptor(false);
+
+    // Publisher without BLOCKED_REQUEST_KEY and processFilter returns false
+    Publisher publisher = new Publisher();
+    publisher.setDataInfoId("test-dataid#@#DEFAULT_INSTANCE_ID#@#test-group");
+    publisher.setDataId("test-dataid");
+    publisher.setGroup("test-group");
+    publisher.setInstanceId("DEFAULT_INSTANCE_ID");
+
+    RegisterInvokeData registerInvokeData = new RegisterInvokeData(publisher, null);
+    TouchChecker touchChecker = new TouchChecker(registerInvokeData);
+
+    WrapperInvocation<RegisterInvokeData, Boolean> invocation =
+        new WrapperInvocation<>(touchChecker, Collections.singletonList(interceptor));
+    Boolean result = invocation.proceed();
+
+    // Should pass through to the next wrapper
+    Assert.assertTrue(result);
+    Assert.assertTrue(touchChecker.hasBeenChecked());
+  }
+
+  @SuppressWarnings("unchecked")
+  private BlacklistWrapperInterceptor createInterceptor(boolean processFilterMatch)
+      throws Exception {
+    return createInterceptor(
+        processFilterMatch,
+        Mockito.mock(SessionRegistry.class),
+        Mockito.mock(FirePushService.class));
+  }
+
+  @SuppressWarnings("unchecked")
+  private BlacklistWrapperInterceptor createInterceptor(
+      boolean processFilterMatch, SessionRegistry sessionRegistry, FirePushService firePushService)
+      throws Exception {
+    BlacklistWrapperInterceptor interceptor = new BlacklistWrapperInterceptor();
+
+    ProcessFilter processFilter = Mockito.mock(ProcessFilter.class);
+    Mockito.when(processFilter.match(Mockito.any())).thenReturn(processFilterMatch);
+
+    setField(interceptor, "sessionRegistry", sessionRegistry);
+    setField(interceptor, "firePushService", firePushService);
+    setField(interceptor, "processFilter", processFilter);
+
+    return interceptor;
+  }
+
+  private void setField(Object target, String fieldName, Object value) throws Exception {
+    Field field = target.getClass().getDeclaredField(fieldName);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+}


### PR DESCRIPTION
## Summary
- Add `testClientOffInZoneNotThrottled` and `testClientOnInZoneNotThrottled` to cover the not-throttled execution paths (L167/172/209/214) in `ClientManagerResource` zone methods
- Add `BlacklistWrapperInterceptorTest` to cover the `BLOCKED_REQUEST_KEY` attribute check (L55) with tests for publisher blocked, subscriber blocked, and pass-through scenarios

## Test plan
- [x] `ClientManagerResourceThrottlingTest` — 14 tests pass (2 new)
- [x] `BlacklistWrapperInterceptorTest` — 3 tests pass (new file)
- [x] Full session module test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)